### PR TITLE
ヘッダーを作成した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  helper_method :logged_in?
+  helper_method :logged_in?, :current_user
 
   private
 
   def logged_in?
-    !!session[:user_id]
+    !!current_user
+  end
+
+  def current_user
+    return unless session[:user_id]
+
+    @current_user ||= User.find(session[:user_id])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,17 +1,4 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  helper_method :logged_in?, :current_user
-
-  private
-
-  def logged_in?
-    !!current_user
-  end
-
-  def current_user
-    return unless session[:user_id]
-
-    @current_user ||= User.find(session[:user_id])
-  end
 end

--- a/app/helpers/user_sessions_helper.rb
+++ b/app/helpers/user_sessions_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module UserSessionsHelper
+  def current_user
+    return unless session[:user_id]
+
+    @current_user ||= User.find(session[:user_id])
+  end
+
+  def logged_in?
+    !!current_user
+  end
+end

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -1,0 +1,15 @@
+.navbar.bg-base-100
+  .flex-1
+    = link_to '2次会GO！',
+              root_path,
+              class: 'btn btn-ghost text-xl'
+  - if logged_in?
+    .flex-none.gap-2
+      .dropdown.dropdown-end
+        .btn.btn-ghost.btn-circle.avatar tabindex="0" role="button"
+          .w-10.rounded-full
+            = image_tag(current_user.image_url)
+        ul.mt-3.z-1.p-2.shadow.menu.menu-sm.dropdown-content.bg-base-100.rounded-box.w-52 tabindex="0"
+          li
+            div
+              = button_to 'ログアウト', logout_path, method: :delete

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -1,19 +1,18 @@
 p style="color: green" = notice
 
-h1.text-3xl.font-bold.mb-4
-  | 2次会GO！
-
 p.mb-4
   | 2次会GO！は、テック系イベントの二次会参加者を簡単に集めることができる、二次会参加者募集ツールです。
 
 .mb-4
-  = link_to '2次会グループを作成', new_group_path
-
-.mb-4
   - if logged_in?
-    = button_to 'ログアウト', logout_path, method: :delete
+    = link_to '2次会グループを作成',
+              new_group_path,
+              class: 'btn'
   - else
-    = button_to 'サインアップ / ログインをして2次会グループを作成', '/auth/github', data: { turbo: false }
+    = button_to 'サインアップ / ログインをして2次会グループを作成',
+                '/auth/github',
+                data: { turbo: false },
+                class: 'btn'
     span.text-xs
       | GitHubアカウントが必要です
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,5 +12,7 @@ html
     link[href="https://cdn.jsdelivr.net/npm/daisyui@4.10.5/dist/full.min.css" rel="stylesheet" type="text/css"]
     script[src="https://cdn.tailwindcss.com"]
   body
-    main.container.mx-auto.mt-28.px-5
-      = yield
+    .container.mx-auto
+      = render 'application/header'
+      main
+        = yield

--- a/spec/helpers/user_sessions_helper_spec.rb
+++ b/spec/helpers/user_sessions_helper_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserSessionsHelper, type: :helper do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe '#current_user' do
+    context 'when user is logged in' do
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'returns the current user' do
+        expect(helper.current_user).to eq(user)
+      end
+    end
+
+    context 'when user is not logged in' do
+      it 'returns nil' do
+        expect(helper.current_user).to be_nil
+      end
+    end
+  end
+
+  describe '#logged_in?' do
+    context 'when user is logged in' do
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'returns true' do
+        expect(helper).to be_logged_in
+      end
+    end
+
+    context 'when user is not logged in' do
+      it 'returns false' do
+        expect(helper).not_to be_logged_in
+      end
+    end
+  end
+end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -5,11 +5,15 @@ require 'rails_helper'
 RSpec.describe 'Groups', type: :system do
   let(:group) { FactoryBot.create(:group) }
 
+  before do
+    Rails.application.env_config['omniauth.auth'] = github_mock
+  end
+
   describe 'creating a new group' do
     context 'with valid input' do
       it 'creates the group' do
         visit root_path
-        click_link '2次会グループを作成'
+        click_button 'サインアップ / ログインをして2次会グループを作成'
         expect(page).to have_current_path(new_group_path)
 
         expect do
@@ -31,7 +35,7 @@ RSpec.describe 'Groups', type: :system do
     context 'with invalid input' do
       it 'displays an error message' do
         visit root_path
-        click_link '2次会グループを作成'
+        click_button 'サインアップ / ログインをして2次会グループを作成'
         expect(page).to have_current_path(new_group_path)
 
         expect do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Users', type: :system do
       it 'allows users to login' do
         visit root_path
         expect(page).to have_content 'GitHubアカウントが必要です'
+        expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
 
         expect do
           click_button 'サインアップ / ログインをして2次会グループを作成'
@@ -20,6 +21,7 @@ RSpec.describe 'Users', type: :system do
         end.to change(User, :count).by(1)
 
         expect(page).to have_current_path(new_group_path)
+        expect(page).to have_css('.avatar img[src="https://example.com/testuser.png"]')
       end
     end
 
@@ -31,6 +33,7 @@ RSpec.describe 'Users', type: :system do
       it 'redirects to root_path' do
         visit root_path
         expect(page).to have_content 'GitHubアカウントが必要です'
+        expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
 
         expect do
           click_button 'サインアップ / ログインをして2次会グループを作成'
@@ -39,6 +42,7 @@ RSpec.describe 'Users', type: :system do
         end.not_to change(User, :count)
 
         expect(page).to have_current_path(root_path)
+        expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
       end
     end
 
@@ -46,18 +50,18 @@ RSpec.describe 'Users', type: :system do
       it 'allows users to logout' do
         visit root_path
         expect(page).to have_content 'GitHubアカウントが必要です'
-        expect(page).not_to have_content 'ログアウト'
+        expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
 
         click_button 'サインアップ / ログインをして2次会グループを作成'
         expect(page).to have_current_path(new_group_path)
+        expect(page).to have_css('.avatar img[src="https://example.com/testuser.png"]')
 
-        click_link 'キャンセル'
-        expect(page).to have_current_path(groups_path)
-        expect(page).not_to have_content 'GitHubアカウントが必要です'
-
+        find('.avatar').click
         click_button 'ログアウト'
+        expect(page).to have_current_path(root_path)
         expect(page).to have_content 'ログアウトしました'
         expect(page).to have_content 'GitHubアカウントが必要です'
+        expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
       end
     end
   end


### PR DESCRIPTION
## Issue
- #68

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- 全ページに共通のヘッダーを作成しました
  - ヘッダーにサービス名とユーザアイコンを配置
  - ログイン中のみユーザアイコンを表示(未ログイン時は何も表示しない)
  - ユーザアイコンにgithubのプロフィール画像を表示
  - ユーザアイコンをクリックするとログアウトリンクが表示される
- トップ画面のレイアウト、システムスペックを修正しました
- `UserSessionsHelper`を作成しました

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [Navbar with search input and dropdown - daisyUI](https://daisyui.com/components/navbar/#navbar-with-search-input-and-dropdown)
- [パーフェクトRuby on Rails - 6.4.3](https://github.com/perfect-ruby-on-rails/awesome_events)
- [Helper specs - RSpec](https://rspec.info/features/6-1/rspec-rails/helper-specs/helper-spec/)
- [ruby - Capybara - Click element by class name - Stack Overflow](https://stackoverflow.com/questions/43396872/capybara-click-element-by-class-name)

## 動作確認方法
1. `feat/#68/add-header`をローカルに取り込む
2. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
3. 「サインアップ / ログインをして2次会グループを作成」をクリックしてログイン
4. ヘッダーにユーザアイコン(GitHubのプロフィール画像)が表示されることを確認する
5. ヘッダーのユーザアイコンをクリック > ログアウトリンクをクリック
6.  ログアウト後にヘッダーのユーザアイコンが表示されなくなることを確認する

## スクリーンショット
### 変更前
ログイン前
![loggedOut_before](https://github.com/djkazunoko/nijikai-go/assets/65595901/888e304c-b702-4dcd-9e2c-374078b8e2ec)

ログイン後
![loggedIn_before](https://github.com/djkazunoko/nijikai-go/assets/65595901/badb5a0c-7e3b-4b72-8432-cceb7b4c360b)


### 変更後
ログイン前
![loggedOut_after](https://github.com/djkazunoko/nijikai-go/assets/65595901/f06e9a17-6901-4eb9-8083-8f44341129a0)

ログイン後
![loggedIn_after](https://github.com/djkazunoko/nijikai-go/assets/65595901/40fa125a-c933-4321-a8e8-ac910d30f2e3)
