### PR TITLE
退会機能を実装した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include UserSessionsHelper
 end

--- a/app/controllers/retirements_controller.rb
+++ b/app/controllers/retirements_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RetirementsController < ApplicationController
+  def create
+    return unless current_user.destroy
+
+    reset_session
+    redirect_to root_path, notice: 'アカウントが削除されました'
+  end
+end

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -11,5 +11,6 @@
             = image_tag(current_user.image_url)
         ul.mt-3.z-1.p-2.shadow.menu.menu-sm.dropdown-content.bg-base-100.rounded-box.w-52 tabindex="0"
           li
-            div
-              = button_to 'ログアウト', logout_path, method: :delete
+            = button_to 'ログアウト', logout_path, method: :delete
+          li
+            = button_to 'アカウント削除', retirements_path, data: { turbo_confirm: '本当に削除しますか？' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
   get "auth/:provider/callback" => "user_sessions#create"
   get "auth/failure" => "user_sessions#failure"
   delete "/logout" => "user_sessions#destroy"
+  post "/retirements" => "retirements#create"
 end

--- a/spec/requests/retirements_spec.rb
+++ b/spec/requests/retirements_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Retirements', type: :request do
+  before do
+    Rails.application.env_config['omniauth.auth'] = github_mock
+    get '/auth/github/callback'
+  end
+
+  describe 'POST /create' do
+    it 'deletes the user from the database' do
+      expect do
+        post retirements_path
+      end.to change(User, :count).by(-1)
+    end
+
+    it 'removes user id from session' do
+      expect(session[:user_id]).to be_present
+      post retirements_path
+      expect(session[:user_id]).to be_nil
+    end
+
+    it 'redirects to root_path' do
+      post retirements_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -45,24 +45,43 @@ RSpec.describe 'Users', type: :system do
         expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
       end
     end
+  end
 
-    context 'when user logs out' do
-      it 'allows users to logout' do
-        visit root_path
-        expect(page).to have_content 'GitHubアカウントが必要です'
-        expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
+  describe 'user logout' do
+    it 'allows users to logout' do
+      visit root_path
+      expect(page).to have_content 'GitHubアカウントが必要です'
+      expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
 
-        click_button 'サインアップ / ログインをして2次会グループを作成'
-        expect(page).to have_current_path(new_group_path)
-        expect(page).to have_css('.avatar img[src="https://example.com/testuser.png"]')
+      click_button 'サインアップ / ログインをして2次会グループを作成'
+      expect(page).to have_current_path(new_group_path)
+      expect(page).to have_css('.avatar img[src="https://example.com/testuser.png"]')
 
-        find('.avatar').click
-        click_button 'ログアウト'
+      find('.avatar').click
+      click_button 'ログアウト'
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content 'ログアウトしました'
+      expect(page).to have_content 'GitHubアカウントが必要です'
+      expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
+    end
+  end
+
+  describe 'user account deletion' do
+    it 'allows users to delete their accounts' do
+      visit root_path
+      click_button 'サインアップ / ログインをして2次会グループを作成'
+      expect(page).to have_current_path(new_group_path)
+      expect(page).to have_css('.avatar img[src="https://example.com/testuser.png"]')
+
+      find('.avatar').click
+      expect do
+        accept_confirm do
+          click_button 'アカウント削除'
+        end
         expect(page).to have_current_path(root_path)
-        expect(page).to have_content 'ログアウトしました'
-        expect(page).to have_content 'GitHubアカウントが必要です'
+        expect(page).to have_content 'アカウントが削除されました'
         expect(page).not_to have_css('.avatar img[src="https://example.com/testuser.png"]')
-      end
+      end.to change(User, :count).by(-1)
     end
   end
 end


### PR DESCRIPTION
## Issue
- #72 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- ユーザが自身のアカウントを削除できる機能を実装しました
  - アカウント削除ボタンを選択すると確認ダイアログが表示されます
  - アカウント削除後はトップページにリダイレクトされます

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [パーフェクトRuby on Rails - 6.8](https://github.com/perfect-ruby-on-rails/awesome_events)

## 動作確認方法
1. `feat/#72/add-retirements`をローカルに取り込む
2. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
3. 「サインアップ / ログインをして2次会グループを作成」を選択してログイン
4. ヘッダーのユーザアイコンを選択 > アカウント削除リンクを選択
5. 確認ダイアログが表示されることを確認する
6. アカウント削除後にトップページにリダイレクトされることを確認する
7. 「アカウントが削除されました」のフラッシュメッセージが表示されていることを確認する
8. アカウント削除後にログイン前の状態に戻っていることを確認する(ログインボタンの文言、ユーザアイコンの非表示)

## スクリーンショット
### 変更前
![nav_before](https://github.com/djkazunoko/nijikai-go/assets/65595901/31cd11ef-b383-479a-a24c-6e32399f6a34)

### 変更後
![retirementsBottun_after](https://github.com/djkazunoko/nijikai-go/assets/65595901/778aff9a-9128-4627-8022-ca86927484f8)

![dialog_after](https://github.com/djkazunoko/nijikai-go/assets/65595901/f638cde7-a1ba-4e5d-9026-bee88cde51c7)

![flash_after](https://github.com/djkazunoko/nijikai-go/assets/65595901/f6e7c37e-0d9b-4a3e-acd3-6c20e72de309)