### PR TITLE
グループ参加機能を実装した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,4 +86,5 @@ end
 group :test do
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'shoulda-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,6 +318,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (6.2.0)
+      activesupport (>= 5.2.0)
     slim (5.2.1)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
@@ -413,6 +415,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   selenium-webdriver
+  shoulda-matchers
   slim-rails
   slim_lint
   sprockets-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,5 @@ class ApplicationController < ActionController::Base
   before_action :authenticate
 
   include UserSessionsHelper
+  include TicketHelper
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,6 +10,7 @@ class GroupsController < ApplicationController
 
   def show
     @group = Group.find(params[:id])
+    @tickets = @group.tickets.includes(:user).order(:created_at)
   end
 
   def new

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,6 +10,7 @@ class GroupsController < ApplicationController
 
   def show
     @group = Group.find(params[:id])
+    @ticket = current_user&.tickets&.find_by(group: @group)
     @tickets = @group.tickets.includes(:user).order(:created_at)
   end
 

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -8,4 +8,10 @@ class TicketsController < ApplicationController
       redirect_to group, notice: '2次会グループに参加しました'
     end
   end
+
+  def destroy
+    ticket = current_user.tickets.find_by!(group_id: params[:group_id])
+    ticket.destroy!
+    redirect_to group_path(params[:group_id]), notice: 'この2次会グループの参加をキャンセルしました'
+  end
 end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -6,6 +6,8 @@ class TicketsController < ApplicationController
     ticket = current_user.tickets.build(group:)
     if ticket.save
       redirect_to group, notice: '2次会グループに参加しました'
+    else
+      redirect_to group, alert: ticket.errors.full_messages.to_sentence
     end
   end
 

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TicketsController < ApplicationController
+  def create
+    group = Group.find(params[:group_id])
+    ticket = current_user.tickets.build(group:)
+    if ticket.save
+      redirect_to group, notice: '2次会グループに参加しました'
+    end
+  end
+end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -2,13 +2,7 @@
 
 class TicketsController < ApplicationController
   def create
-    group = Group.find(params[:group_id])
-    ticket = current_user.tickets.build(group:)
-    if ticket.save
-      redirect_to group, notice: '2次会グループに参加しました'
-    else
-      redirect_to group, alert: ticket.errors.full_messages.to_sentence
-    end
+    create_ticket_and_redirect(current_user, params[:group_id])
   end
 
   def destroy

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,13 @@ class UserSessionsController < ApplicationController
   def create
     user = User.find_or_create_from_auth_hash!(request.env['omniauth.auth'])
     session[:user_id] = user.id
-    redirect_to new_group_path, notice: 'ログインしました'
+    params = request.env['omniauth.params']
+
+    if params['group_id']
+      create_ticket_and_redirect(user, params['group_id'])
+    else
+      redirect_to new_group_path, notice: 'ログインしました'
+    end
   end
 
   def destroy

--- a/app/helpers/ticket_helper.rb
+++ b/app/helpers/ticket_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module TicketHelper
+  def create_ticket_and_redirect(user, group_id)
+    group = Group.find(group_id)
+    ticket = user.tickets.build(group:)
+    if ticket.save
+      redirect_to group, notice: '2次会グループに参加しました'
+    else
+      redirect_to group, alert: ticket.errors.full_messages.to_sentence
+    end
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -11,6 +11,8 @@ class Group < ApplicationRecord
   validates :location, presence: true
   validates :payment_method, presence: true
 
+  validate :capacity_cannot_be_less_than_participants, on: :update
+
   def created_by?(user)
     return false unless user
 
@@ -19,5 +21,13 @@ class Group < ApplicationRecord
 
   def can_participate?
     tickets.count < capacity
+  end
+
+  private
+
+  def capacity_cannot_be_less_than_participants
+    return unless capacity < tickets.count
+
+    errors.add(:capacity, 'は参加人数以上の値にしてください')
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -16,4 +16,8 @@ class Group < ApplicationRecord
 
     owner_id == user.id
   end
+
+  def can_participate?
+    tickets.count < capacity
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,6 +2,7 @@
 
 class Group < ApplicationRecord
   belongs_to :owner, class_name: 'User', inverse_of: :groups
+  has_many :tickets, dependent: :destroy
 
   validates :hashtag, presence: true
   validates :name, presence: true

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -6,6 +6,7 @@ class Ticket < ApplicationRecord
 
   validates :group_id, uniqueness: { scope: :user_id }
   validate :participants_cannot_exceed_capacity
+  validate :owner_cannot_participate
 
   private
 
@@ -13,5 +14,11 @@ class Ticket < ApplicationRecord
     return unless group.tickets.count >= group.capacity
 
     errors.add(:base, '定員を超えて参加することはできません')
+  end
+
+  def owner_cannot_participate
+    return unless group.created_by?(user)
+
+    errors.add(:base, '自身が主催したグループには参加できません')
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,0 +1,4 @@
+class Ticket < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -5,4 +5,13 @@ class Ticket < ApplicationRecord
   belongs_to :group
 
   validates :group_id, uniqueness: { scope: :user_id }
+  validate :participants_cannot_exceed_capacity
+
+  private
+
+  def participants_cannot_exceed_capacity
+    return unless group.tickets.count >= group.capacity
+
+    errors.add(:base, '定員を超えて参加することはできません')
+  end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
+
 class Ticket < ApplicationRecord
   belongs_to :user
   belongs_to :group
+
+  validates :group_id, uniqueness: { scope: :user_id }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  before_destroy :check_no_groups_exist
+  before_destroy :check_no_owned_groups_exist
+  before_destroy :check_no_participating_groups_exist
 
   has_many :groups, foreign_key: :owner_id, dependent: :destroy, inverse_of: :owner
   has_many :tickets, dependent: :destroy
@@ -25,10 +26,17 @@ class User < ApplicationRecord
 
   private
 
-  def check_no_groups_exist
+  def check_no_owned_groups_exist
     return unless groups.exists?
 
     errors.add(:base, '主催の2次会グループが存在するため、アカウントを削除できません')
+    throw(:abort)
+  end
+
+  def check_no_participating_groups_exist
+    return unless tickets.exists?
+
+    errors.add(:base, '参加中の2次会グループが存在するため、アカウントを削除できません')
     throw(:abort)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   before_destroy :check_no_groups_exist
 
   has_many :groups, foreign_key: :owner_id, dependent: :destroy, inverse_of: :owner
+  has_many :tickets, dependent: :destroy
 
   validates :provider, presence: true
   validates :uid, presence: true, uniqueness: { scope: :provider }

--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -10,7 +10,10 @@ div id="#{dom_id group}"
   p
     = "#{Group.human_attribute_name('details')}: #{group.details}"
   p
-    = "参加者: 0 / #{group.capacity}人"
+    = "参加者: #{tickets.count} / #{group.capacity}人"
+    - tickets.each do |ticket|
+      = link_to("https://github.com/#{ticket.user.name}", target: '_blank', rel: 'noopener') do
+        = image_tag(ticket.user.image_url, width: '50', height: '50')
   p
     = "#{Group.human_attribute_name('location')}: #{group.location}"
   p

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -30,7 +30,7 @@ p.text-xl.font-bold.mb-4
     p
       = group.details
     p
-      = "0 / #{group.capacity}人"
+      = "#{group.tickets.count} / #{group.capacity}人"
     p
       = "▼ #{group.location}"
     p.mb-4

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -1,5 +1,5 @@
 .mb-4
-  == render @group
+  == render partial: 'groups/group', locals: { group: @group, tickets: @tickets }
 
 div
   - if @group.created_by?(current_user)
@@ -7,3 +7,8 @@ div
     = button_to '削除', @group, method: :delete, data: { turbo_confirm: '本当に削除しますか？' }
 
   = link_to '2次会グループ一覧に戻る', groups_path
+
+div
+  - if logged_in?
+    = form_with(url: group_tickets_path(@group)) do |form|
+      = form.submit "この2次会グループに参加する"

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -15,7 +15,7 @@ div
     - elsif @group.can_participate?
       - if logged_in?
         = form_with(url: group_tickets_path(@group)) do |form|
-          = form.submit "この2次会グループに参加する"
+          = form.submit 'この2次会グループに参加する'
       - else
         = button_to 'サインアップ / ログインをして2次会グループに参加',
                     "/auth/github/?group_id=#{@group.id}",

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -9,12 +9,13 @@ div
   = link_to '2次会グループ一覧に戻る', groups_path
 
 div
-  - if @ticket
-    = button_to '参加をキャンセルする', group_ticket_path(@group, @ticket), method: :delete
-  - elsif @group.can_participate?
-    - if logged_in?
-      = form_with(url: group_tickets_path(@group)) do |form|
-        = form.submit "この2次会グループに参加する"
-  - else
-    p
-     | 定員に達したため参加できません
+  - unless @group.created_by?(current_user)
+    - if @ticket
+      = button_to '参加をキャンセルする', group_ticket_path(@group, @ticket), method: :delete
+    - elsif @group.can_participate?
+      - if logged_in?
+        = form_with(url: group_tickets_path(@group)) do |form|
+          = form.submit "この2次会グループに参加する"
+    - else
+      p
+        | 定員に達したため参加できません

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -16,6 +16,11 @@ div
       - if logged_in?
         = form_with(url: group_tickets_path(@group)) do |form|
           = form.submit "この2次会グループに参加する"
+      - else
+        = button_to 'サインアップ / ログインをして2次会グループに参加',
+                    "/auth/github/?group_id=#{@group.id}",
+                    data: { turbo: false },
+                    class: 'btn'
     - else
       p
         | 定員に達したため参加できません

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -11,6 +11,10 @@ div
 div
   - if @ticket
     = button_to '参加をキャンセルする', group_ticket_path(@group, @ticket), method: :delete
-  - elsif logged_in?
-    = form_with(url: group_tickets_path(@group)) do |form|
-      = form.submit "この2次会グループに参加する"
+  - elsif @group.can_participate?
+    - if logged_in?
+      = form_with(url: group_tickets_path(@group)) do |form|
+        = form.submit "この2次会グループに参加する"
+  - else
+    p
+     | 定員に達したため参加できません

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -9,6 +9,8 @@ div
   = link_to '2次会グループ一覧に戻る', groups_path
 
 div
-  - if logged_in?
+  - if @ticket
+    = button_to '参加をキャンセルする', group_ticket_path(@group, @ticket), method: :delete
+  - elsif logged_in?
     = form_with(url: group_tickets_path(@group)) do |form|
       = form.submit "この2次会グループに参加する"

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,6 @@ module Nijikaigo
     # Don't generate system test files.
     config.generators.system_tests = nil
     config.i18n.default_locale = :ja
+    config.active_model.i18n_customize_full_message = true
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,3 +10,12 @@ ja:
         capacity: 定員
         location: 会場
         payment_method: 会計方法
+      ticket:
+        group_id: 2次会グループ
+    errors:
+      models:
+        ticket:
+          attributes:
+            group_id:
+              format: '%{message}'
+              taken: この%{attribute}には既に参加しています

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,12 @@
 Rails.application.routes.draw do
-  resources :groups
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
   root "groups#index"
+  resources :groups do
+    resources :tickets, only: [:create]
+  end
   get "auth/:provider/callback" => "user_sessions#create"
   get "auth/failure" => "user_sessions#failure"
   delete "/logout" => "user_sessions#destroy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   root "groups#index"
   resources :groups do
-    resources :tickets, only: [:create]
+    resources :tickets, only: [:create, :destroy]
   end
   get "auth/:provider/callback" => "user_sessions#create"
   get "auth/failure" => "user_sessions#failure"

--- a/db/migrate/20240709042357_create_tickets.rb
+++ b/db/migrate/20240709042357_create_tickets.rb
@@ -1,0 +1,12 @@
+class CreateTickets < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tickets do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :group, null: false, foreign_key: true, index: false
+
+      t.timestamps
+    end
+
+    add_index :tickets, %i[group_id user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_17_094846) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_09_042357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_17_094846) do
     t.index ["owner_id"], name: "index_groups_on_owner_id"
   end
 
+  create_table "tickets", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id", "user_id"], name: "index_tickets_on_group_id_and_user_id", unique: true
+    t.index ["user_id"], name: "index_tickets_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "provider", null: false
     t.string "uid", null: false
@@ -40,4 +49,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_17_094846) do
   end
 
   add_foreign_key "groups", "users", column: "owner_id"
+  add_foreign_key "tickets", "groups"
+  add_foreign_key "tickets", "users"
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -13,5 +13,12 @@ FactoryBot.define do
     trait :invalid do
       hashtag { nil }
     end
+
+    trait :full_capacity do
+      capacity { 1 }
+      after(:create) do |group|
+        create(:ticket, group:)
+      end
+    end
   end
 end

--- a/spec/factories/tickets.rb
+++ b/spec/factories/tickets.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :ticket do
+    user { nil }
+    group { nil }
+  end
+end

--- a/spec/factories/tickets.rb
+++ b/spec/factories/tickets.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :ticket do
-    user { nil }
-    group { nil }
+    association :user
+    association :group
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,14 +3,14 @@
 FactoryBot.define do
   factory :user, aliases: [:owner] do
     provider { 'github' }
-    uid { '0001' }
-    name { 'alice' }
-    image_url { 'https://example.com/alice.png' }
+    sequence(:uid) { |n| "000#{n}" }
+    sequence(:name) { |n| "user#{n}" }
+    sequence(:image_url) { |n| "https://example.com/user#{n}.png" }
 
-    trait :bob do
-      uid { '0002' }
-      name { 'bob' }
-      image_url { 'https://example.com/bob.png' }
+    trait :alice do
+      uid { '1111' }
+      name { 'alice' }
+      image_url { 'https://example.com/alice.png' }
     end
   end
 end

--- a/spec/helpers/user_sessions_helper_spec.rb
+++ b/spec/helpers/user_sessions_helper_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe UserSessionsHelper, type: :helper do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
 
   describe '#current_user' do
     context 'when user is logged in' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Group, type: :model do
-  let(:group) { FactoryBot.build(:group) }
+  let(:group) { build(:group) }
 
   it 'is valid with all attributes' do
     expect(group).to be_valid

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Ticket, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Ticket, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject { build(:ticket) }
+
+  it { is_expected.to validate_uniqueness_of(:group_id).scoped_to(:user_id) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
 
   it 'is valid with all attributes' do
     expect(user).to be_valid
@@ -35,29 +35,29 @@ RSpec.describe User, type: :model do
     end
 
     it 'is invalid with a duplicate name' do
-      FactoryBot.create(:user)
-      user2 = FactoryBot.build(:user, image_url: 'https://example.com/bob.png', provider: 'twitter', uid: '0002')
+      create(:user)
+      user2 = build(:user, image_url: 'https://example.com/bob.png', provider: 'twitter', uid: '0002')
       user2.valid?
       expect(user2.errors[:name]).to include('はすでに存在します')
     end
 
     it 'is invalid with a duplicate image_url' do
-      FactoryBot.create(:user)
-      user2 = FactoryBot.build(:user, name: 'bob', provider: 'twitter', uid: '0002')
+      create(:user)
+      user2 = build(:user, name: 'bob', provider: 'twitter', uid: '0002')
       user2.valid?
       expect(user2.errors[:image_url]).to include('はすでに存在します')
     end
 
     it 'is invalid with a duplicate uid and provider pair' do
-      FactoryBot.create(:user)
-      user2 = FactoryBot.build(:user, name: 'bob', image_url: 'https://example.com/bob.png')
+      create(:user)
+      user2 = build(:user, name: 'bob', image_url: 'https://example.com/bob.png')
       user2.valid?
       expect(user2.errors[:uid]).to include('はすでに存在します')
     end
 
     it 'allows duplicate uid with different provider' do
-      FactoryBot.create(:user)
-      user2 = FactoryBot.build(:user, name: 'bob', image_url: 'https://example.com/bob.png', provider: 'twitter')
+      create(:user)
+      user2 = build(:user, name: 'bob', image_url: 'https://example.com/bob.png', provider: 'twitter')
       expect(user2).to be_valid
     end
   end
@@ -93,7 +93,7 @@ RSpec.describe User, type: :model do
     end
 
     context 'when user already exists' do
-      before { FactoryBot.create(:user) }
+      before { create(:user) }
 
       it 'does not create a new user' do
         expect do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,61 +3,61 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { create(:user) }
+  let(:alice) { create(:user, :alice) }
 
   it 'is valid with all attributes' do
-    expect(user).to be_valid
+    expect(alice).to be_valid
   end
 
   describe 'validations' do
     it 'is invalid without a provider' do
-      user.provider = nil
-      user.valid?
-      expect(user.errors[:provider]).to include('を入力してください')
+      alice.provider = nil
+      alice.valid?
+      expect(alice.errors[:provider]).to include('を入力してください')
     end
 
     it 'is invalid without a uid' do
-      user.uid = nil
-      user.valid?
-      expect(user.errors[:uid]).to include('を入力してください')
+      alice.uid = nil
+      alice.valid?
+      expect(alice.errors[:uid]).to include('を入力してください')
     end
 
     it 'is invalid without a name' do
-      user.name = nil
-      user.valid?
-      expect(user.errors[:name]).to include('を入力してください')
+      alice.name = nil
+      alice.valid?
+      expect(alice.errors[:name]).to include('を入力してください')
     end
 
     it 'is invalid without an image_url' do
-      user.image_url = nil
-      user.valid?
-      expect(user.errors[:image_url]).to include('を入力してください')
+      alice.image_url = nil
+      alice.valid?
+      expect(alice.errors[:image_url]).to include('を入力してください')
     end
 
     it 'is invalid with a duplicate name' do
-      create(:user)
-      user2 = build(:user, image_url: 'https://example.com/bob.png', provider: 'twitter', uid: '0002')
+      create(:user, :alice)
+      user2 = build(:user, name: 'alice')
       user2.valid?
       expect(user2.errors[:name]).to include('はすでに存在します')
     end
 
     it 'is invalid with a duplicate image_url' do
-      create(:user)
-      user2 = build(:user, name: 'bob', provider: 'twitter', uid: '0002')
+      create(:user, :alice)
+      user2 = build(:user, image_url: 'https://example.com/alice.png')
       user2.valid?
       expect(user2.errors[:image_url]).to include('はすでに存在します')
     end
 
     it 'is invalid with a duplicate uid and provider pair' do
-      create(:user)
-      user2 = build(:user, name: 'bob', image_url: 'https://example.com/bob.png')
+      create(:user, :alice)
+      user2 = build(:user, uid: '1111')
       user2.valid?
       expect(user2.errors[:uid]).to include('はすでに存在します')
     end
 
     it 'allows duplicate uid with different provider' do
-      create(:user)
-      user2 = build(:user, name: 'bob', image_url: 'https://example.com/bob.png', provider: 'twitter')
+      create(:user, :alice)
+      user2 = build(:user, provider: 'twitter', uid: '1111')
       expect(user2).to be_valid
     end
   end
@@ -66,10 +66,10 @@ RSpec.describe User, type: :model do
     let(:auth_hash) do
       {
         provider: 'github',
-        uid: '0001',
+        uid: '1111',
         info: {
-          nickname: 'alice',
-          image: 'https://example.com/alice.png'
+          nickname: 'bob',
+          image: 'https://example.com/bob.png'
         }
       }
     end
@@ -85,15 +85,15 @@ RSpec.describe User, type: :model do
         user = described_class.find_or_create_from_auth_hash!(auth_hash)
         expect(user).to have_attributes(
           provider: 'github',
-          uid: '0001',
-          name: 'alice',
-          image_url: 'https://example.com/alice.png'
+          uid: '1111',
+          name: 'bob',
+          image_url: 'https://example.com/bob.png'
         )
       end
     end
 
-    context 'when user already exists' do
-      before { create(:user) }
+    context 'when user with the same uid and provider pair already exists' do
+      before { create(:user, :alice) }
 
       it 'does not create a new user' do
         expect do
@@ -105,7 +105,7 @@ RSpec.describe User, type: :model do
         user = described_class.find_or_create_from_auth_hash!(auth_hash)
         expect(user).to have_attributes(
           provider: 'github',
-          uid: '0001',
+          uid: '1111',
           name: 'alice',
           image_url: 'https://example.com/alice.png'
         )

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,3 +65,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe '/groups', type: :request do
   let(:owner) { create(:user) }
-  let(:bob) { build(:user, :bob) }
+  let(:alice) { build(:user, :alice) }
   let(:valid_attributes) { build(:group, owner:).attributes }
   let(:invalid_attributes) { build(:group, :invalid, owner:).attributes }
 
@@ -27,7 +27,7 @@ RSpec.describe '/groups', type: :request do
   describe 'GET /new' do
     context 'when authenticated' do
       before do
-        github_mock(bob)
+        github_mock(alice)
         login
       end
 
@@ -61,7 +61,7 @@ RSpec.describe '/groups', type: :request do
 
     context 'when other user' do
       before do
-        github_mock(bob)
+        github_mock(alice)
         login
       end
 
@@ -84,7 +84,7 @@ RSpec.describe '/groups', type: :request do
   describe 'POST /create' do
     context 'when authenticated' do
       before do
-        github_mock(bob)
+        github_mock(alice)
         login
       end
 
@@ -151,7 +151,7 @@ RSpec.describe '/groups', type: :request do
 
     context 'when other user' do
       before do
-        github_mock(bob)
+        github_mock(alice)
         login
       end
 
@@ -194,7 +194,7 @@ RSpec.describe '/groups', type: :request do
 
     context 'when other user' do
       before do
-        github_mock(bob)
+        github_mock(alice)
         login
       end
 

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe '/groups', type: :request do
-  let(:owner) { FactoryBot.create(:user) }
-  let(:bob) { FactoryBot.build(:user, :bob) }
-  let(:valid_attributes) { FactoryBot.build(:group, owner:).attributes }
-  let(:invalid_attributes) { FactoryBot.build(:group, :invalid, owner:).attributes }
+  let(:owner) { create(:user) }
+  let(:bob) { build(:user, :bob) }
+  let(:valid_attributes) { build(:group, owner:).attributes }
+  let(:invalid_attributes) { build(:group, :invalid, owner:).attributes }
 
   describe 'GET /index' do
     it 'renders a successful response' do
@@ -120,7 +120,7 @@ RSpec.describe '/groups', type: :request do
   end
 
   describe 'PATCH /update' do
-    let(:new_attributes) { FactoryBot.attributes_for(:group, name: 'New Group Name') }
+    let(:new_attributes) { attributes_for(:group, name: 'New Group Name') }
 
     context 'when owner' do
       before do

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -147,6 +147,13 @@ RSpec.describe '/groups', type: :request do
         patch group_url(group), params: { group: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_entity)
       end
+
+      it 'renders a response with 422 status when capacity is set less than the number of participants' do
+        group = Group.create! valid_attributes
+        create_list(:ticket, 2, group:)
+        patch group_url(group), params: { group: { capacity: 1 } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
 
     context 'when other user' do

--- a/spec/requests/retirements_spec.rb
+++ b/spec/requests/retirements_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Retirements', type: :request do
   before do
-    github_mock(FactoryBot.build(:user))
+    github_mock(build(:user))
     login
   end
 

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Tickets", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -1,7 +1,129 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Tickets", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe 'Tickets', type: :request do
+  let(:alice) { build(:user, :alice) }
+  let(:group) { create(:group) }
+
+  describe 'POST /create' do
+    context 'when logged in and meeting the participation requirements' do
+      before do
+        github_mock(alice)
+        login
+      end
+
+      it 'allows the user to join the group' do
+        expect do
+          post group_tickets_path(group)
+        end.to change(Ticket, :count).by(1)
+      end
+
+      it 'displays a message after redirection' do
+        post group_tickets_path(group)
+        expect(response).to redirect_to(group_url(group))
+        follow_redirect!
+        expect(response.body).to include('2次会グループに参加しました')
+      end
+    end
+
+    context 'when not logged in' do
+      it 'does not allow the user to join the group' do
+        expect do
+          post group_tickets_path(group)
+        end.not_to change(Ticket, :count)
+      end
+
+      it 'displays an error message after redirection' do
+        post group_tickets_path(group)
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(response.body).to include('ログインしてください')
+      end
+    end
+
+    context 'when already participating in the group' do
+      before do
+        create(:ticket, user: alice, group:)
+        github_mock(alice)
+        login
+      end
+
+      it 'does not allow the user to join the group again' do
+        expect do
+          post group_tickets_path(group)
+        end.not_to change(Ticket, :count)
+      end
+
+      it 'displays an error message after redirection' do
+        post group_tickets_path(group)
+        expect(response).to redirect_to(group_url(group))
+        follow_redirect!
+        expect(response.body).to include('この2次会グループには既に参加しています')
+      end
+    end
+
+    context 'when the group has reached its capacity' do
+      let(:full_capacity_group) { create(:group, :full_capacity) }
+
+      before do
+        github_mock(alice)
+        login
+      end
+
+      it 'does not allow the user to join the group' do
+        expect do
+          post group_tickets_path(full_capacity_group)
+        end.not_to change(alice.tickets, :count)
+      end
+
+      it 'displays an error message after redirection' do
+        post group_tickets_path(full_capacity_group)
+        expect(response).to redirect_to(group_url(full_capacity_group))
+        follow_redirect!
+        expect(response.body).to include('定員を超えて参加することはできません')
+      end
+    end
+
+    context 'when the user is the group owner' do
+      before do
+        github_mock(group.owner)
+        login
+      end
+
+      it 'does not allow the user to join the group' do
+        expect do
+          post group_tickets_path(group)
+        end.not_to change(Ticket, :count)
+      end
+
+      it 'displays an error message after redirection' do
+        post group_tickets_path(group)
+        expect(response).to redirect_to(group_url(group))
+        follow_redirect!
+        expect(response.body).to include('自身が主催したグループには参加できません')
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    before do
+      github_mock(alice)
+      login
+    end
+
+    it 'allows the user to cancel participation' do
+      post group_tickets_path(group)
+      expect do
+        delete group_ticket_path(group, Ticket.first)
+      end.to change(Ticket, :count).by(-1)
+    end
+
+    it 'displays a message after redirection' do
+      post group_tickets_path(group)
+      delete group_ticket_path(group, Ticket.first)
+      follow_redirect!
+      expect(response.body).to include('この2次会グループの参加をキャンセルしました')
+    end
   end
 end

--- a/spec/requests/user_sessions_spec.rb
+++ b/spec/requests/user_sessions_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'UserSessions', type: :request do
   before do
-    github_mock(FactoryBot.build(:user))
+    github_mock(build(:user))
   end
 
   describe 'POST /create' do

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 
 RSpec.describe 'Groups', type: :system do
   let(:group) { create(:group) }
-  let(:bob) { build(:user, :bob) }
+  let(:alice) { build(:user, :alice) }
 
   describe 'creating a new group' do
     before do
-      github_mock(bob)
+      github_mock(alice)
     end
 
     context 'with valid input' do
@@ -101,7 +101,7 @@ RSpec.describe 'Groups', type: :system do
 
     context 'when other user' do
       before do
-        github_mock(bob)
+        github_mock(alice)
         visit root_path
         click_button 'サインアップ / ログインをして2次会グループを作成'
       end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -97,6 +97,21 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_content '会場を入力してください'
         expect(page).to have_current_path(edit_group_path(group))
       end
+
+      it 'does not allow setting capacity less than the number of participants' do
+        create_list(:ticket, 2, group:)
+
+        visit group_path(group)
+        click_link '編集'
+        expect(page).to have_current_path(edit_group_path(group))
+
+        fill_in '定員', with: '1'
+        click_button '更新する'
+
+        expect(page).to have_content '2次会グループに1個のエラーが発生しました'
+        expect(page).to have_content '定員は参加人数以上の値にしてください'
+        expect(page).to have_current_path(edit_group_path(group))
+      end
     end
 
     context 'when other user' do

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Groups', type: :system do
-  let(:group) { FactoryBot.create(:group) }
-  let(:bob) { FactoryBot.build(:user, :bob) }
+  let(:group) { create(:group) }
+  let(:bob) { build(:user, :bob) }
 
   describe 'creating a new group' do
     before do

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Tickets', type: :system do
+  let(:alice) { build(:user, :alice) }
+  let(:group) { create(:group) }
+
+  describe 'group participation' do
+    context 'when not logged in' do
+      before do
+        github_mock(alice)
+      end
+
+      it 'logs in and allows the user to join the group' do
+        visit group_path(group)
+
+        expect(page).not_to have_css('.avatar')
+        expect(page).not_to have_link href: "https://github.com/#{alice.name}"
+        expect(page).to have_content "0 / #{group.capacity}人"
+        expect(page).not_to have_button '参加をキャンセルする'
+
+        expect do
+          click_button 'サインアップ / ログインをして2次会グループに参加'
+          expect(page).to have_content '2次会グループに参加しました'
+          expect(page).to have_css(".avatar img[src='#{alice.image_url}']")
+          expect(page).to have_link href: "https://github.com/#{alice.name}"
+          expect(page).to have_content "1 / #{group.capacity}人"
+          expect(page).to have_button '参加をキャンセルする'
+        end.to change(Ticket, :count).by(1)
+      end
+    end
+
+    context 'when logged in and meeting the participation requirements' do
+      before do
+        github_mock(alice)
+        visit '/auth/github/callback'
+      end
+
+      it 'allows the user to join the group' do
+        visit group_path(group)
+
+        expect(page).not_to have_link href: "https://github.com/#{alice.name}"
+        expect(page).to have_content "0 / #{group.capacity}人"
+        expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
+        expect(page).not_to have_button '参加をキャンセルする'
+
+        expect do
+          click_button 'この2次会グループに参加する'
+          expect(page).to have_content '2次会グループに参加しました'
+          expect(page).to have_link href: "https://github.com/#{alice.name}"
+          expect(page).to have_content "1 / #{group.capacity}人"
+          expect(page).to have_button '参加をキャンセルする'
+        end.to change(Ticket, :count).by(1)
+      end
+    end
+
+    context 'when already participating in the group and not logged in' do
+      before do
+        github_mock(alice)
+        create(:ticket, user: alice, group:)
+      end
+
+      it 'does not allow the user to join the group' do
+        visit group_path(group)
+
+        expect(page).to have_link href: "https://github.com/#{alice.name}"
+
+        expect do
+          click_button 'サインアップ / ログインをして2次会グループに参加'
+          expect(page).to have_content 'この2次会グループには既に参加しています'
+        end.not_to change(Ticket, :count)
+      end
+    end
+
+    context 'when the group has reached its capacity' do
+      let(:full_capacity_group) { create(:group, :full_capacity) }
+
+      it 'does not display participation button' do
+        visit group_path(full_capacity_group)
+        expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
+        expect(page).to have_content '定員に達したため参加できません'
+      end
+    end
+
+    context 'when the user is the group owner and logged in' do
+      before do
+        github_mock(group.owner)
+        visit '/auth/github/callback'
+      end
+
+      it 'does not display participation button' do
+        visit group_path(group)
+        expect(page).not_to have_button 'この2次会グループに参加する'
+      end
+    end
+
+    context 'when the user is the group owner and not logged in' do
+      before do
+        github_mock(group.owner)
+      end
+
+      it 'does not allow the user to join the group' do
+        visit group_path(group)
+
+        expect do
+          click_button 'サインアップ / ログインをして2次会グループに参加'
+          expect(page).to have_content '自身が主催したグループには参加できません'
+        end.not_to change(Ticket, :count)
+      end
+    end
+  end
+
+  describe 'group participation cancellation' do
+    before do
+      github_mock(alice)
+    end
+
+    it 'allows the user to cancel participation' do
+      visit group_path(group)
+      click_button 'サインアップ / ログインをして2次会グループに参加'
+
+      expect(page).to have_link href: "https://github.com/#{alice.name}"
+      expect(page).to have_content "1 / #{group.capacity}人"
+
+      expect do
+        click_button '参加をキャンセルする'
+        expect(page).to have_content 'この2次会グループの参加をキャンセルしました'
+        expect(page).not_to have_link href: "https://github.com/#{alice.name}"
+        expect(page).to have_content "0 / #{group.capacity}人"
+        expect(page).to have_button 'この2次会グループに参加する'
+      end.to change(Ticket, :count).by(-1)
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -3,16 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :system do
+  let(:user) { build(:user) }
+  let(:group) { create(:group) }
+
   describe 'login' do
     context 'when authentication is successful' do
       before do
-        github_mock(build(:user))
+        github_mock(user)
       end
 
       it 'can login' do
         visit root_path
         expect(page).to have_content 'GitHubアカウントが必要です'
-        expect(page).not_to have_css('.avatar img[src="https://example.com/alice.png"]')
+        expect(page).not_to have_css('.avatar')
 
         expect do
           click_button 'サインアップ / ログインをして2次会グループを作成'
@@ -21,7 +24,7 @@ RSpec.describe 'Users', type: :system do
         end.to change(User, :count).by(1)
 
         expect(page).to have_current_path(new_group_path)
-        expect(page).to have_css('.avatar img[src="https://example.com/alice.png"]')
+        expect(page).to have_css(".avatar img[src='#{user.image_url}']")
       end
     end
 
@@ -33,7 +36,7 @@ RSpec.describe 'Users', type: :system do
       it 'redirects to root_path' do
         visit root_path
         expect(page).to have_content 'GitHubアカウントが必要です'
-        expect(page).not_to have_css('.avatar img[src="https://example.com/alice.png"]')
+        expect(page).not_to have_css('.avatar')
 
         expect do
           click_button 'サインアップ / ログインをして2次会グループを作成'
@@ -42,45 +45,45 @@ RSpec.describe 'Users', type: :system do
         end.not_to change(User, :count)
 
         expect(page).to have_current_path(root_path)
-        expect(page).not_to have_css('.avatar img[src="https://example.com/alice.png"]')
+        expect(page).not_to have_css('.avatar')
       end
     end
   end
 
   describe 'logout' do
     before do
-      github_mock(build(:user))
+      github_mock(user)
     end
 
     it 'can logout' do
       visit root_path
       expect(page).to have_content 'GitHubアカウントが必要です'
-      expect(page).not_to have_css('.avatar img[src="https://example.com/alice.png"]')
+      expect(page).not_to have_css('.avatar')
 
       click_button 'サインアップ / ログインをして2次会グループを作成'
       expect(page).to have_current_path(new_group_path)
-      expect(page).to have_css('.avatar img[src="https://example.com/alice.png"]')
+      expect(page).to have_css(".avatar img[src='#{user.image_url}']")
 
       find('.avatar').click
       click_button 'ログアウト'
       expect(page).to have_current_path(root_path)
       expect(page).to have_content 'ログアウトしました'
       expect(page).to have_content 'GitHubアカウントが必要です'
-      expect(page).not_to have_css('.avatar img[src="https://example.com/alice.png"]')
+      expect(page).not_to have_css('.avatar')
     end
   end
 
   describe 'delete account' do
     context 'when no hosted groups exist' do
       before do
-        github_mock(build(:user))
+        github_mock(user)
       end
 
       it 'can delete own account' do
         visit root_path
         click_button 'サインアップ / ログインをして2次会グループを作成'
         expect(page).to have_current_path(new_group_path)
-        expect(page).to have_css('.avatar img[src="https://example.com/alice.png"]')
+        expect(page).to have_css(".avatar img[src='#{user.image_url}']")
 
         find('.avatar').click
         expect do
@@ -89,14 +92,13 @@ RSpec.describe 'Users', type: :system do
           end
           expect(page).to have_current_path(root_path)
           expect(page).to have_content 'アカウントが削除されました'
-          expect(page).not_to have_css('.avatar img[src="https://example.com/alice.png"]')
+          expect(page).not_to have_css('.avatar')
         end.to change(User, :count).by(-1)
       end
     end
 
     context 'when hosted groups exist' do
       before do
-        group = create(:group)
         github_mock(group.owner)
       end
 
@@ -104,7 +106,7 @@ RSpec.describe 'Users', type: :system do
         visit root_path
         click_button 'サインアップ / ログインをして2次会グループを作成'
         expect(page).to have_current_path(new_group_path)
-        expect(page).to have_css('.avatar img[src="https://example.com/alice.png"]')
+        expect(page).to have_css(".avatar img[src='#{group.owner.image_url}']")
 
         find('.avatar').click
         expect do
@@ -113,7 +115,7 @@ RSpec.describe 'Users', type: :system do
           end
           expect(page).to have_current_path(root_path)
           expect(page).to have_content '主催の2次会グループが存在するため、アカウントを削除できません'
-          expect(page).to have_css('.avatar img[src="https://example.com/alice.png"]')
+          expect(page).to have_css(".avatar img[src='#{group.owner.image_url}']")
         end.not_to change(User, :count)
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Users', type: :system do
   describe 'login' do
     context 'when authentication is successful' do
       before do
-        github_mock(FactoryBot.build(:user))
+        github_mock(build(:user))
       end
 
       it 'can login' do
@@ -49,7 +49,7 @@ RSpec.describe 'Users', type: :system do
 
   describe 'logout' do
     before do
-      github_mock(FactoryBot.build(:user))
+      github_mock(build(:user))
     end
 
     it 'can logout' do
@@ -73,7 +73,7 @@ RSpec.describe 'Users', type: :system do
   describe 'delete account' do
     context 'when no hosted groups exist' do
       before do
-        github_mock(FactoryBot.build(:user))
+        github_mock(build(:user))
       end
 
       it 'can delete own account' do
@@ -96,7 +96,7 @@ RSpec.describe 'Users', type: :system do
 
     context 'when hosted groups exist' do
       before do
-        group = FactoryBot.create(:group)
+        group = create(:group)
         github_mock(group.owner)
       end
 


### PR DESCRIPTION
## Issue
- #76 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [x] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- グループ参加処理を実装した
  - グループ詳細に参加者のアイコンと人数を表示
  - グループ一覧に参加者の人数を表示
- 未ログイン時の参加ボタンを実装した
  - ボタンクリックでログインとグループ参加が連続して実行される
- グループ参加キャンセル処理を実装した
- グループ参加に関する制限を追加した
  - 参加済みグループに重複して参加できないようにした
  - グループの定員を超えて参加できないようにした
  - 自身が主催したグループには参加できないようにした
  - 定員を参加人数より少ない値に変更できないようにした
- 参加中のグループがある場合は退会できないようにした
- Userファクトリの修正に伴い、影響する他のテストを修正した

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [パーフェクトRuby on Rails - 6.7](https://github.com/perfect-ruby-on-rails/awesome_events)
- [Active Record バリデーション - Railsガイド](https://railsguides.jp/active_record_validations.html)
- [レイアウトとレンダリング - Railsガイド](https://railsguides.jp/layouts_and_rendering.html)
- [thoughtbot/factory_bot](https://github.com/thoughtbot/factory_bot)

## 動作確認方法
1. `feat/#76/add-group-participation`をローカルに取り込む
1. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
1. ユーザAで任意のグループAを作成
1. ユーザBでログイン
1. グループAの詳細ページに移動
1. 「この2次会グループに参加する」ボタンを選択してグループ参加処理を実行する
1. グループAの詳細ページで参加者数が1増加していること、ユーザBのアイコンが表示されていることを確認する
1. 「参加をキャンセルする」ボタンを選択してグループ参加キャンセル処理を実行する
1. グループAの詳細ページで参加者数が1減少していること、ユーザBのアイコンが表示されていないことを確認する

※現状ローカル環境で異なるユーザでログインする方法は実装されていないため、`rails console`で`User.create()`してユーザを作成して`session[:user_id]`に直接ユーザidを入れるなどしてログイン状態を再現する

## スクリーンショット
### 変更前
`/groups/{ID}`
![before](https://github.com/user-attachments/assets/63d400b0-98dd-4d85-9496-c6e18c02d50c)

### 変更後
未ログイン時
![not_loggedIn](https://github.com/user-attachments/assets/c8d50701-6c33-4f1e-b31e-fc6f8f74742d)

ログイン済み
![loggedIn](https://github.com/user-attachments/assets/6e00b1f8-3ce5-4700-a627-14ca4522c963)

グループ参加
![participattion](https://github.com/user-attachments/assets/ab832b6a-a071-4d44-bdd2-00012ee5d6b4)

グループ参加キャンセル
![cancelation](https://github.com/user-attachments/assets/f9902c78-8117-4b0e-89d9-6cd16db2a63e)

参加済みのグループの場合
![already_participating](https://github.com/user-attachments/assets/48ebf9f2-af92-442c-885c-98fb181efbe7)

グループの定員に達している場合
![full_capacity](https://github.com/user-attachments/assets/359fc05c-a4fc-4b00-9f03-caf2ff3c3376)

グループの主催者の場合
![owner](https://github.com/user-attachments/assets/4da876c5-ada7-4e79-bc7f-eecb26794161)

定員を参加人数より少ない値に変更した場合
![capacity_participant](https://github.com/user-attachments/assets/213a1a19-7e37-43c5-b144-507050296025)
