### PR TITLE
Xのシェアボタンを作成した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'active_decorator'
 gem 'omniauth'
 gem 'omniauth-github'
 gem 'omniauth-rails_csrf_protection'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_decorator (1.4.1)
+      activesupport
     activejob (7.1.3.2)
       activesupport (= 7.1.3.2)
       globalid (>= 0.3.6)
@@ -391,6 +393,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_decorator
   bootsnap
   capybara
   debug

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GroupDecorator
+  def twitter_share_url
+    # https://developer.x.com/en/docs/x-for-websites/tweet-button/guides/web-intent
+    query_params = {
+      url: Rails.application.routes.url_helpers.group_url(self),
+      hashtags: "#{hashtag},2次会GO",
+      text: "#{hashtag}の2次会に参加しよう！"
+    }
+    "https://twitter.com/intent/tweet?#{URI.encode_www_form(query_params)}"
+  end
+end

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -24,3 +24,9 @@ div
     - else
       p
         | 定員に達したため参加できません
+
+div
+  = link_to 'Xでシェアして参加者を募集する',
+            @group.twitter_share_url,
+            target: '_blank', rel: 'noopener',
+            class: 'btn'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,4 +61,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
 end

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GroupDecorator do
+  include Rails.application.routes.url_helpers
+  let(:group) { create(:group).extend described_class }
+
+  describe '#twitter_share_url' do
+    it 'returns tweet web intent url' do
+      query_params = {
+        url: group_url(group),
+        hashtags: "#{group.hashtag},2次会GO",
+        text: "#{group.hashtag}の2次会に参加しよう！"
+      }
+      expected_url = "https://twitter.com/intent/tweet?#{URI.encode_www_form(query_params)}"
+      expect(group.twitter_share_url).to eq expected_url
+    end
+  end
+end


### PR DESCRIPTION
## Issue
- #78 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [x] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- グループ詳細ページにXのシェアボタンを追加した
- XのシェアボタンをクリックするとXの投稿画面に遷移する
- 以下の内容があらかじめ入力された投稿が作成される
  - `#{イベントのハッシュタグ}の2次会に参加しよう！`
  - 2次会グループのURL
  - イベントのハッシュタグ
  - `#2次会GO`

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [Tweet button | Twitter Developer Platform](https://developer.x.com/en/docs/x-for-websites/tweet-button/overview)
- [ウェブサイトにツイートボタンを追加する方法](https://help.x.com/ja/using-x/add-x-share-button)
- [amatsuda/active_decorator](https://github.com/amatsuda/active_decorator)

## 動作確認方法
1. `feat/#78/add-tweetbutton`をローカルに取り込む
1. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
1. 任意のグループを作成
1. 作成したグループの詳細ページ(`/groups/{ID}`)に移動
1. `Xでシェアして参加者を募集する`ボタンを選択
1. Xの投稿画面に遷移することを確認する
1. 2次会グループのURL、イベントのハッシュタグなどが投稿に含まれていることを確認する

## スクリーンショット
### 変更前
`/groups/{ID}`
![before1](https://github.com/user-attachments/assets/63a5bebc-f144-42b1-a4fe-2b1294fc9f23)

### 変更後
`/groups/{ID}`
![after1](https://github.com/user-attachments/assets/82d9b0ae-d44f-40fc-a0ca-bf22673d3ebe)

シェアボタン選択後のXの投稿画面
![after2](https://github.com/user-attachments/assets/2aaa4f56-91d6-49fc-946d-f5de3455f93f)
