### PR TITLE
掲示板機能を実装した

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,6 +12,7 @@ class GroupsController < ApplicationController
     @group = Group.find(params[:id])
     @ticket = current_user&.tickets&.find_by(group: @group)
     @tickets = @group.tickets.includes(:user).order(:created_at)
+    @posts = @group.posts.includes(:user).order(:created_at)
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PostsController < ApplicationController
+  def create
+    group = Group.find(params[:group_id])
+    post = current_user.posts.build do |t|
+      t.group = group
+      t.content = params[:post][:content]
+    end
+
+    if post.save
+      redirect_to group, notice: '投稿が作成されました'
+    else
+      redirect_to group, alert: post.errors.full_messages.to_sentence
+    end
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,4 +14,10 @@ class PostsController < ApplicationController
       redirect_to group, alert: post.errors.full_messages.to_sentence
     end
   end
+
+  def destroy
+    post = current_user.posts.find(params[:id])
+    post.destroy!
+    redirect_to group_path(params[:group_id]), notice: '投稿が削除されました'
+  end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -11,7 +11,7 @@ class UserSessionsController < ApplicationController
     if params['group_id']
       create_ticket_and_redirect(user, params['group_id'])
     else
-      redirect_to new_group_path, notice: 'ログインしました'
+      redirect_to request.env['omniauth.origin'] || root_path, notice: 'ログインしました'
     end
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,6 +3,7 @@
 class Group < ApplicationRecord
   belongs_to :owner, class_name: 'User', inverse_of: :groups
   has_many :tickets, dependent: :destroy
+  has_many :posts, dependent: :destroy
 
   validates :hashtag, presence: true
   validates :name, presence: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Post < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :group
+
+  validates :content, presence: true
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,13 +5,4 @@ class Post < ApplicationRecord
   belongs_to :group
 
   validates :content, presence: true
-  validate :user_cannot_post_if_not_member_or_owner
-
-  private
-
-  def user_cannot_post_if_not_member_or_owner
-    return if group.created_by?(user) || group.tickets.exists?(user:)
-
-    errors.add(:base, 'このグループに参加していないため、投稿できません')
-  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,7 +4,7 @@ class Post < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :group
 
-  validates :content, presence: true
+  validates :content, length: { maximum: 2000 }, presence: true
 
   def created_by?(user)
     return false unless user

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,4 +5,13 @@ class Post < ApplicationRecord
   belongs_to :group
 
   validates :content, presence: true
+  validate :user_cannot_post_if_not_member_or_owner
+
+  private
+
+  def user_cannot_post_if_not_member_or_owner
+    return if group.created_by?(user) || group.tickets.exists?(user:)
+
+    errors.add(:base, 'このグループに参加していないため、投稿できません')
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,4 +5,10 @@ class Post < ApplicationRecord
   belongs_to :group
 
   validates :content, presence: true
+
+  def created_by?(user)
+    return false unless user
+
+    user_id == user.id
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :groups, foreign_key: :owner_id, dependent: :destroy, inverse_of: :owner
   has_many :tickets, dependent: :destroy
+  has_many :posts, dependent: :destroy
 
   validates :provider, presence: true
   validates :uid, presence: true, uniqueness: { scope: :provider }

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -8,7 +8,7 @@ p.mb-4
               class: 'btn'
   - else
     = button_to 'サインアップ / ログインをして2次会グループを作成',
-                '/auth/github',
+                "/auth/github?origin=#{new_group_path}",
                 data: { turbo: false },
                 class: 'btn'
     span.text-xs

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -40,14 +40,21 @@ div
           .w-10.rounded-full
             = link_to("https://github.com/#{post.user.name}", target: '_blank', rel: 'noopener') do
               = image_tag(post.user.image_url, alt: post.user.name)
-        .chat-bubble
-          = post.content
-        .chat-footer
+        .chat-header
           span.text-xs
             = post.user.name
             | &nbsp;
           time.text-xs.opacity-50
             = l post.created_at, format: :short
+        .flex.items-end.gap-x-2
+          .chat-bubble
+            = post.content
+          - if post.created_by?(current_user)
+            = button_to '削除',
+                        group_post_path(@group, post),
+                        method: :delete,
+                        data: { turbo_confirm: '本当に削除しますか？' },
+                        class: 'text-xs'
   - else
     p
       | まだコメントはありません。

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -38,13 +38,13 @@ div
       == render partial: 'posts/post', locals: { post: post, group: @group }
   - else
     p
-      | まだコメントはありません。
+      | まだ投稿はありません。
 
 div
   - if logged_in?
     == render 'posts/form', group: @group
   - else
-    = button_to 'サインアップ / ログインをしてコメントを投稿する',
+    = button_to 'サインアップ / ログインをして投稿を作成する',
                 '/auth/github',
                 data: { turbo: false },
                 class: 'btn'

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -35,7 +35,7 @@ div
   h2 掲示板
   - if @posts.any?
     - @posts.each do |post|
-      == render partial: 'posts/post', locals: { post: post, group: @group }
+      == render partial: 'posts/post', locals: { post:, group: @group }
   - else
     p
       | まだ投稿はありません。

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -53,4 +53,10 @@ div
       | まだコメントはありません。
 
 div
-  == render 'posts/form', group: @group
+  - if logged_in?
+    == render 'posts/form', group: @group
+  - else
+    = button_to 'サインアップ / ログインをしてコメントを投稿する',
+                '/auth/github',
+                data: { turbo: false },
+                class: 'btn'

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -35,26 +35,7 @@ div
   h2 掲示板
   - if @posts.any?
     - @posts.each do |post|
-      .chat.chat-start
-        .chat-image.avatar
-          .w-10.rounded-full
-            = link_to("https://github.com/#{post.user.name}", target: '_blank', rel: 'noopener') do
-              = image_tag(post.user.image_url, alt: post.user.name)
-        .chat-header
-          span.text-xs
-            = post.user.name
-            | &nbsp;
-          time.text-xs.opacity-50
-            = l post.created_at, format: :short
-        .flex.items-end.gap-x-2
-          .chat-bubble
-            = post.content
-          - if post.created_by?(current_user)
-            = button_to '削除',
-                        group_post_path(@group, post),
-                        method: :delete,
-                        data: { turbo_confirm: '本当に削除しますか？' },
-                        class: 'text-xs'
+      == render partial: 'posts/post', locals: { post: post, group: @group }
   - else
     p
       | まだコメントはありません。

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -30,3 +30,27 @@ div
             @group.twitter_share_url,
             target: '_blank', rel: 'noopener',
             class: 'btn'
+
+div
+  h2 掲示板
+  - if @posts.any?
+    - @posts.each do |post|
+      .chat.chat-start
+        .chat-image.avatar
+          .w-10.rounded-full
+            = link_to("https://github.com/#{post.user.name}", target: '_blank', rel: 'noopener') do
+              = image_tag(post.user.image_url, alt: post.user.name)
+        .chat-bubble
+          = post.content
+        .chat-footer
+          span.text-xs
+            = post.user.name
+            | &nbsp;
+          time.text-xs.opacity-50
+            = l post.created_at, format: :short
+  - else
+    p
+      | まだコメントはありません。
+
+div
+  == render 'posts/form', group: @group

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,5 +1,5 @@
 = form_with(model: [group, Post.new]) do |form|
-  = form.text_field :content, placeholder: 'コメントを入力', class: 'input input-bordered w-full max-w-xs'
+  = form.text_field :content, placeholder: '投稿内容を入力', class: 'input input-bordered w-full max-w-xs'
 
   div
-    = form.submit 'コメントを投稿する', class: 'btn'
+    = form.submit '投稿を作成する', class: 'btn'

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,0 +1,5 @@
+= form_with(model: [group, Post.new]) do |form|
+  = form.text_field :content, placeholder: 'コメントを入力', class: 'input input-bordered w-full max-w-xs'
+
+  div
+    = form.submit 'コメントを投稿する', class: 'btn'

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -1,0 +1,20 @@
+.chat.chat-start
+  .chat-image.avatar
+    .w-10.rounded-full
+      = link_to("https://github.com/#{post.user.name}", target: '_blank', rel: 'noopener') do
+        = image_tag(post.user.image_url, alt: post.user.name)
+  .chat-header
+    span.text-xs
+      = post.user.name
+      | &nbsp;
+    time.text-xs.opacity-50
+      = l post.created_at, format: :short
+  .flex.items-end.gap-x-2
+    .chat-bubble
+      = post.content
+    - if post.created_by?(current_user)
+      = button_to '削除',
+                  group_post_path(group, post),
+                  method: :delete,
+                  data: { turbo_confirm: '本当に削除しますか？' },
+                  class: 'text-xs'

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,6 @@ module Nijikaigo
     config.generators.system_tests = nil
     config.i18n.default_locale = :ja
     config.active_model.i18n_customize_full_message = true
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,8 @@ ja:
         payment_method: 会計方法
       ticket:
         group_id: 2次会グループ
+      post:
+        content: 投稿内容
     errors:
       models:
         ticket:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   root "groups#index"
   resources :groups do
     resources :tickets, only: [:create, :destroy]
-    resources :posts, only: [:create]
+    resources :posts, only: [:create, :destroy]
   end
   get "auth/:provider/callback" => "user_sessions#create"
   get "auth/failure" => "user_sessions#failure"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   root "groups#index"
   resources :groups do
     resources :tickets, only: [:create, :destroy]
+    resources :posts, only: [:create]
   end
   get "auth/:provider/callback" => "user_sessions#create"
   get "auth/failure" => "user_sessions#failure"

--- a/db/migrate/20240920005845_create_posts.rb
+++ b/db/migrate/20240920005845_create_posts.rb
@@ -1,0 +1,11 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+      t.references :user, foreign_key: true
+      t.references :group, null: false, foreign_key: true
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_09_042357) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_20_005845) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_09_042357) do
     t.datetime "updated_at", null: false
     t.bigint "owner_id", null: false
     t.index ["owner_id"], name: "index_groups_on_owner_id"
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "group_id", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_posts_on_group_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "tickets", force: :cascade do |t|
@@ -49,6 +59,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_09_042357) do
   end
 
   add_foreign_key "groups", "users", column: "owner_id"
+  add_foreign_key "posts", "groups"
+  add_foreign_key "posts", "users"
   add_foreign_key "tickets", "groups"
   add_foreign_key "tickets", "users"
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :post do
+    user { nil }
+    group { nil }
+    content { "MyText" }
+  end
+end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :post do
-    user { nil }
-    group { nil }
-    content { "MyText" }
+    content { 'MyText' }
+    association :user
+    association :group
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,5 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#created_by?' do
+    let(:alice) { create(:user, :alice) }
+    let(:bob) { create(:user) }
+    let(:group) { create(:group) }
+    let(:post) { create(:post, user: alice, group:) }
+
+    context 'when the user is the creator of the post' do
+      it 'returns true' do
+        expect(post.created_by?(alice)).to be true
+      end
+    end
+
+    context 'when the user is not the creator of the post' do
+      it 'returns false' do
+        expect(post.created_by?(bob)).to be false
+      end
+    end
+
+    context 'when the user is nil' do
+      it 'returns false' do
+        expect(post.created_by?(nil)).to be false
+      end
+    end
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:content) }
+    it { is_expected.to validate_length_of(:content).is_at_most(2000) }
+  end
+
   describe '#created_by?' do
     let(:alice) { create(:user, :alice) }
     let(:bob) { create(:user) }

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -7,42 +7,9 @@ RSpec.describe 'Posts', type: :request do
   let(:alice) { build(:user, :alice) }
 
   describe 'POST /groups/:id/posts' do
-    context 'when user is a member of the group' do
-      before do
-        create(:ticket, group:, user: alice)
-        github_mock(alice)
-        login
-      end
-
-      it 'creates a post and redirects to the group page' do
-        expect do
-          post group_posts_path(group), params: { post: { content: 'test post' } }
-        end.to change(Post, :count).by(1)
-
-        expect(response).to redirect_to(group_path(group))
-      end
-    end
-
-    context 'when user is not a member of the group' do
+    context 'when user is logged in' do
       before do
         github_mock(alice)
-        login
-      end
-
-      it 'does not create a post and redirects to the group page with an error message' do
-        expect do
-          post group_posts_path(group), params: { post: { content: 'test post' } }
-        end.not_to change(Post, :count)
-
-        expect(response).to redirect_to(group_path(group))
-        follow_redirect!
-        expect(response.body).to include('このグループに参加していないため、投稿できません')
-      end
-    end
-
-    context 'when user is the group owner' do
-      before do
-        github_mock(group.owner)
         login
       end
 

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
   let(:group) { create(:group) }
-  let(:alice) { build(:user, :alice) }
+  let(:alice) { create(:user, :alice) }
 
   describe 'POST /groups/:id/posts' do
     context 'when user is logged in' do
@@ -28,6 +28,55 @@ RSpec.describe 'Posts', type: :request do
           post group_posts_path(group), params: { post: { content: 'test post' } }
         end.not_to change(Post, :count)
 
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'DELETE /groups/:id/posts/:id' do
+    context 'when logged in as the post owner' do
+      before do
+        github_mock(alice)
+        login
+      end
+
+      it 'deletes a post and redirects to the group page' do
+        post = create(:post, user: alice, group:)
+
+        expect do
+          delete group_post_path(group, post)
+        end.to change(Post, :count).by(-1)
+
+        expect(response).to redirect_to(group_path(group))
+      end
+    end
+
+    context 'when logged in as a non-post owner' do
+      before do
+        github_mock(alice)
+        login
+      end
+
+      it 'does not delete the post and returns a 404 response' do
+        post = create(:post, user: group.owner, group:)
+
+        expect do
+          delete group_post_path(group, post)
+        end.not_to change(Post, :count)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when not logged in' do
+      it 'does not delete the post and redirects to the root path' do
+        post = create(:post, user: alice, group:)
+
+        expect do
+          delete group_post_path(group, post)
+        end.not_to change(Post, :count)
+
+        expect(response).to have_http_status(:found)
         expect(response).to redirect_to(root_path)
       end
     end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Posts', type: :request do
+  let(:group) { create(:group) }
+  let(:alice) { build(:user, :alice) }
+
+  describe 'POST /groups/:id/posts' do
+    context 'when user is a member of the group' do
+      before do
+        create(:ticket, group:, user: alice)
+        github_mock(alice)
+        login
+      end
+
+      it 'creates a post and redirects to the group page' do
+        expect do
+          post group_posts_path(group), params: { post: { content: 'test post' } }
+        end.to change(Post, :count).by(1)
+
+        expect(response).to redirect_to(group_path(group))
+      end
+    end
+
+    context 'when user is not a member of the group' do
+      before do
+        github_mock(alice)
+        login
+      end
+
+      it 'does not create a post and redirects to the group page with an error message' do
+        expect do
+          post group_posts_path(group), params: { post: { content: 'test post' } }
+        end.not_to change(Post, :count)
+
+        expect(response).to redirect_to(group_path(group))
+        follow_redirect!
+        expect(response.body).to include('このグループに参加していないため、投稿できません')
+      end
+    end
+
+    context 'when user is the group owner' do
+      before do
+        github_mock(group.owner)
+        login
+      end
+
+      it 'creates a post and redirects to the group page' do
+        expect do
+          post group_posts_path(group), params: { post: { content: 'test post' } }
+        end.to change(Post, :count).by(1)
+
+        expect(response).to redirect_to(group_path(group))
+      end
+    end
+
+    context 'when user is not logged in' do
+      it 'does not create a post and redirects to the root path' do
+        expect do
+          post group_posts_path(group), params: { post: { content: 'test post' } }
+        end.not_to change(Post, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/user_sessions_spec.rb
+++ b/spec/requests/user_sessions_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe 'UserSessions', type: :request do
         expect(session[:user_id]).to be_present
       end
 
-      it 'redirects to new_group_path' do
+      it 'redirects to root_path' do
         get '/auth/github/callback'
-        expect(response).to redirect_to(new_group_path)
+        expect(response).to redirect_to(root_path)
       end
     end
 

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Posts', type: :system do
         click_button 'コメントを投稿する'
         expect(page).to have_content '投稿が作成されました'
         expect(page).to have_content 'テストコメント'
-        within('.chat-footer') do
+        within('.chat-header') do
           expect(page).to have_content(alice.name)
           expect(page).to have_content(I18n.l(Post.last.created_at, format: :short))
         end
@@ -35,6 +35,56 @@ RSpec.describe 'Posts', type: :system do
       end.to change(Post, :count).by(1)
 
       expect(page).to have_current_path(group_path(group))
+    end
+  end
+
+  describe 'deleting a post' do
+    context 'when logged in as the post owner' do
+      before do
+        github_mock(alice)
+        create(:post, user: alice, group:)
+      end
+
+      it 'deletes a post' do
+        visit group_path(group)
+        expect(page).to have_content 'MyText'
+        within('.chat') do
+          expect(page).not_to have_button '削除'
+        end
+
+        click_button 'サインアップ / ログインをしてコメントを投稿する'
+
+        expect do
+          accept_confirm do
+            within('.chat') do
+              click_button '削除'
+            end
+          end
+
+          expect(page).to have_content '投稿が削除されました'
+          expect(page).not_to have_content 'MyText'
+        end.to change(Post, :count).by(-1)
+
+        expect(page).to have_current_path(group_path(group))
+      end
+    end
+
+    context 'when logged in as a non-post owner' do
+      before do
+        github_mock(group.owner)
+        create(:post, user: alice, group:)
+      end
+
+      it 'does not show the delete button' do
+        visit group_path(group)
+        expect(page).to have_content 'MyText'
+
+        click_button 'サインアップ / ログインをしてコメントを投稿する'
+
+        within('.chat') do
+          expect(page).not_to have_button '削除'
+        end
+      end
     end
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe 'Posts', type: :system do
 
     it 'logs in and creates a post' do
       visit group_path(group)
-      expect(page).to have_content 'まだコメントはありません。'
+      expect(page).to have_content 'まだ投稿はありません。'
 
-      click_button 'サインアップ / ログインをしてコメントを投稿する'
+      click_button 'サインアップ / ログインをして投稿を作成する'
       expect(page).to have_current_path(group_path(group))
 
       expect do
         fill_in 'post_content', with: 'テストコメント'
-        click_button 'コメントを投稿する'
+        click_button '投稿を作成する'
         expect(page).to have_content '投稿が作成されました'
         expect(page).to have_content 'テストコメント'
         within('.chat-header') do
@@ -31,7 +31,7 @@ RSpec.describe 'Posts', type: :system do
           expect(page).to have_link(href: "https://github.com/#{alice.name}")
           expect(page).to have_css("img[src='#{alice.image_url}']")
         end
-        expect(page).not_to have_content 'まだコメントはありません。'
+        expect(page).not_to have_content 'まだ投稿はありません。'
       end.to change(Post, :count).by(1)
 
       expect(page).to have_current_path(group_path(group))
@@ -52,7 +52,7 @@ RSpec.describe 'Posts', type: :system do
           expect(page).not_to have_button '削除'
         end
 
-        click_button 'サインアップ / ログインをしてコメントを投稿する'
+        click_button 'サインアップ / ログインをして投稿を作成する'
 
         expect do
           accept_confirm do
@@ -79,7 +79,7 @@ RSpec.describe 'Posts', type: :system do
         visit group_path(group)
         expect(page).to have_content 'MyText'
 
-        click_button 'サインアップ / ログインをしてコメントを投稿する'
+        click_button 'サインアップ / ログインをして投稿を作成する'
 
         within('.chat') do
           expect(page).not_to have_button '削除'

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Posts', type: :system do
+  let(:group) { create(:group) }
+  let(:alice) { build(:user, :alice) }
+
+  describe 'creating a post' do
+    before do
+      github_mock(alice)
+    end
+
+    it 'logs in and creates a post' do
+      visit group_path(group)
+      expect(page).to have_content 'まだコメントはありません。'
+
+      click_button 'サインアップ / ログインをしてコメントを投稿する'
+      expect(page).to have_current_path(group_path(group))
+
+      expect do
+        fill_in 'post_content', with: 'テストコメント'
+        click_button 'コメントを投稿する'
+        expect(page).to have_content '投稿が作成されました'
+        expect(page).to have_content 'テストコメント'
+        within('.chat-footer') do
+          expect(page).to have_content(alice.name)
+          expect(page).to have_content(I18n.l(Post.last.created_at, format: :short))
+        end
+        within('.chat-image') do
+          expect(page).to have_link(href: "https://github.com/#{alice.name}")
+          expect(page).to have_css("img[src='#{alice.image_url}']")
+        end
+        expect(page).not_to have_content 'まだコメントはありません。'
+      end.to change(Post, :count).by(1)
+
+      expect(page).to have_current_path(group_path(group))
+    end
+  end
+end


### PR DESCRIPTION
## Issue
- #80 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- 投稿作成処理を実装した
  - ログイン済みのユーザが投稿できる(グループに参加していなくても投稿できる)
  - 投稿内容は2000文字まで
- 投稿表示機能を実装した
  - 投稿内容
  - ユーザアイコン
  - ユーザ名
  - 投稿日時
- 投稿削除処理を実装した
  - 投稿を作成したユーザのみ削除できる

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [Saving User Location · omniauth/omniauth Wiki](https://github.com/omniauth/omniauth/wiki/Saving-User-Location)
- [Return to the previous or a specific page after login with OmniAuth — kinopyo — Bloggie](https://bloggie.io/@kinopyo/return-to-the-previous-or-a-specific-page-after-login-with-omniauth)
  - https://github.com/djkazunoko/nijikai-go/pull/77#discussion_r1740230649

## 動作確認方法
1. `feat/#80/add-post-model`をローカルに取り込む
1. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
1. ログインしていない状態で任意のグループの詳細ページ(`/groups/{ID}`)にアクセス
1. `サインアップ / ログインをして投稿を作成する`ボタンをクリックしてログインする
1. 投稿内容を入力し、`投稿を作成する`ボタンをクリックし投稿を作成する
1. 投稿内容、ユーザアイコン、ユーザ名、投稿日時が表示されていることを確認する
1. ログアウトして投稿の削除ボタンが表示されていないことを確認する
1. 投稿を作成していない別のユーザでログインして投稿の削除ボタンが表示されていないことを確認する
1. 投稿を作成したユーザでログインして投稿の削除ボタンをクリックして投稿が削除されることを確認する

※現状ローカル環境で異なるユーザでログインする方法は実装されていないため、`rails console`で`User.create()`してユーザを作成して`session[:user_id]`に直接ユーザidを入れるなどしてログイン状態を再現する

## スクリーンショット
### 変更前
未ログイン
![before_1_not-logged-in](https://github.com/user-attachments/assets/68550cb1-0f61-44db-a106-ec1625069a1e)

ログイン済み
![before_2_logged-in](https://github.com/user-attachments/assets/5c51d2e2-e1f6-4104-b6ba-e6f17bf44a0f)

### 変更後
未ログイン、投稿なし
![after_1_not-logged-in-no-post](https://github.com/user-attachments/assets/25b728a1-ae2e-4b2f-a9e7-4ce6288ffad3)

ログイン済み、投稿なし
![after_2_logged-in-no-post](https://github.com/user-attachments/assets/4f225cce-bca5-4e33-83b7-651accf1e024)

投稿作成
![after_3_create-post](https://github.com/user-attachments/assets/0eca1f03-bd0c-4dbf-89e4-d060843e7e18)

投稿削除
![after_4_delete_post](https://github.com/user-attachments/assets/07f070c2-adee-4db6-9771-a39760222420)

## その他
- ユーザ退会後もそのユーザに紐づくpostを残す機能は未実装
  - 現状はユーザが退会するとそのユーザに紐づくpostは全て削除される