### PR TITLE
掲示板をリアルタイム更新できるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ GitHubのOAuthアプリの登録と`Client ID`、`Client secrets`の設定を行
 
 詳細な手順については、[PR #67](https://github.com/djkazunoko/nijikai-go/pull/67#issue-2221954700) の「**動作確認方法**」>「**1. 事前準備**」セクションを参照してください。
 
+### 3. Redisのインストールと起動
+Turbo StreamsでAction Cableを使用する際にRedisが必要です。
+
+以下の手順でRedisをインストールし、起動します。
+
+```bash
+# macOSの場合
+$ brew install redis
+$ brew services start redis
+```
+
 ## Lint
 ```
 $ bin/lint

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,16 +2,26 @@
 
 class PostsController < ApplicationController
   def create
-    group = Group.find(params[:group_id])
-    post = current_user.posts.build do |t|
-      t.group = group
+    @group = Group.find(params[:group_id])
+    @post = current_user.posts.build do |t|
+      t.group = @group
       t.content = params[:post][:content]
     end
 
-    if post.save
-      redirect_to group, notice: '投稿が作成されました'
-    else
-      redirect_to group, alert: post.errors.full_messages.to_sentence
+    respond_to do |format|
+      if @post.save
+        format.html { redirect_to @group, notice: '投稿が作成されました' }
+        format.turbo_stream { flash.now[:notice] = '投稿が作成されました' }
+      else
+        format.html { redirect_to @group, alert: @post.errors.full_messages.to_sentence }
+        format.turbo_stream do
+          flash.now[:alert] = @post.errors.full_messages.to_sentence
+          render turbo_stream: [
+            turbo_stream.update('new_post', partial: 'posts/form', locals: { group: @group }),
+            turbo_stream.prepend('flash', partial: 'application/flash')
+          ]
+        end
+      end
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,8 +16,11 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    post = current_user.posts.find(params[:id])
-    post.destroy!
-    redirect_to group_path(params[:group_id]), notice: '投稿が削除されました'
+    @post = current_user.posts.find(params[:id])
+    @post.destroy!
+    respond_to do |format|
+      format.html { redirect_to group_path(params[:group_id]), notice: '投稿が削除されました' }
+      format.turbo_stream { flash.now[:notice] = '投稿が削除されました' }
+    end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,7 +17,7 @@ class PostsController < ApplicationController
         format.turbo_stream do
           flash.now[:alert] = @post.errors.full_messages.to_sentence
           render turbo_stream: [
-            turbo_stream.update('new_post', partial: 'posts/form', locals: { group: @group }),
+            turbo_stream.replace('new_post', partial: 'posts/form', locals: { group: @group }),
             turbo_stream.prepend('flash', partial: 'application/flash')
           ]
         end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,13 +14,7 @@ class PostsController < ApplicationController
         format.turbo_stream { flash.now[:notice] = '投稿が作成されました' }
       else
         format.html { redirect_to @group, alert: @post.errors.full_messages.to_sentence }
-        format.turbo_stream do
-          flash.now[:alert] = @post.errors.full_messages.to_sentence
-          render turbo_stream: [
-            turbo_stream.replace('new_post', partial: 'posts/form', locals: { group: @group }),
-            turbo_stream.prepend('flash', partial: 'application/flash')
-          ]
-        end
+        format.turbo_stream { flash.now[:alert] = @post.errors.full_messages.to_sentence }
       end
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,5 +12,6 @@ class Post < ApplicationRecord
     user_id == user.id
   end
 
+  after_create_commit -> { broadcast_append_later_to 'posts', locals: { post: self, group: } }
   after_destroy_commit -> { broadcast_remove_to('posts') }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,6 +12,7 @@ class Post < ApplicationRecord
     user_id == user.id
   end
 
-  after_create_commit -> { broadcast_append_later_to 'posts', locals: { post: self, group: } }
+  after_create_commit -> { broadcast_append_to 'posts', locals: { post: self } }
+  after_create_commit -> { broadcast_append_to user, target: "delete_button_#{id}", partial: 'posts/delete_button', locals: { post: self, group: } }
   after_destroy_commit -> { broadcast_remove_to('posts') }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,4 +11,6 @@ class Post < ApplicationRecord
 
     user_id == user.id
   end
+
+  after_destroy_commit -> { broadcast_remove_to('posts') }
 end

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,6 +1,7 @@
-- if flash[:notice]
-  .text-green-500
-    = flash[:notice]
-- if flash[:alert]
-  .text-red-500
-    = flash[:alert]
+#flash
+  - if flash[:notice]
+    .text-green-500
+      = flash[:notice]
+  - if flash[:alert]
+    .text-red-500
+      = flash[:alert]

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,0 +1,6 @@
+- if flash[:notice]
+  .text-green-500
+    = flash[:notice]
+- if flash[:alert]
+  .text-red-500
+    = flash[:alert]

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -32,13 +32,10 @@ div
 
 .p-4.my-4.shadow-md
   p.mb-4 掲示板
-  .overflow-y-auto.max-h-80
-    - if @posts.any?
-      #posts
-        == render partial: 'posts/post', collection: @posts, locals: { group: @group }
-    - else
-      p
-        | まだ投稿はありません。
+  #posts.overflow-y-auto.max-h-80
+    == render partial: 'posts/post', collection: @posts, locals: { group: @group }
+    .hidden.only:block
+      | まだ投稿はありません。
 
 div
   - if logged_in?

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -34,8 +34,7 @@ div
   p.mb-4 掲示板
   .overflow-y-auto.max-h-80
     - if @posts.any?
-      - @posts.each do |post|
-        == render partial: 'posts/post', locals: { post:, group: @group }
+      == render partial: 'posts/post', collection: @posts, locals: { group: @group }
     - else
       p
         | まだ投稿はありません。

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -1,4 +1,5 @@
 = turbo_stream_from 'posts'
+= turbo_stream_from current_user
 
 .mb-4
   == render partial: 'groups/group', locals: { group: @group, tickets: @tickets }

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -1,3 +1,5 @@
+= turbo_stream_from 'posts'
+
 .mb-4
   == render partial: 'groups/group', locals: { group: @group, tickets: @tickets }
 

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -34,7 +34,8 @@ div
   p.mb-4 掲示板
   .overflow-y-auto.max-h-80
     - if @posts.any?
-      == render partial: 'posts/post', collection: @posts, locals: { group: @group }
+      #posts
+        == render partial: 'posts/post', collection: @posts, locals: { group: @group }
     - else
       p
         | まだ投稿はありません。

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,8 +14,5 @@ html
   body.max-w-screen-sm.mx-auto.min-h-screen.flex.flex-col
     = render 'application/header'
     main
-      - if flash.notice
-        p style="color: green" = notice
-      - if flash.alert
-        p style="color: red" = alert
+      = render 'application/flash'
       = yield

--- a/app/views/posts/_delete_button.html.slim
+++ b/app/views/posts/_delete_button.html.slim
@@ -1,0 +1,5 @@
+= button_to '削除',
+            group_post_path(group, post),
+            method: :delete,
+            data: { turbo_confirm: '本当に削除しますか？' },
+            class: 'text-xs'

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,5 +1,6 @@
-= form_with(model: [group, Post.new], class: 'flex space-x-2') do |form|
-  = form.text_field :content, placeholder: '投稿内容を入力', class: 'input input-bordered flex-grow'
+= turbo_frame_tag 'new_post' do
+  = form_with(model: [group, Post.new], class: 'flex space-x-2') do |form|
+    = form.text_field :content, placeholder: '投稿内容を入力', class: 'input input-bordered flex-grow'
 
-  div
-    = form.submit '投稿を作成する', class: 'btn'
+    div
+      = form.submit '投稿を作成する', class: 'btn'

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -1,20 +1,21 @@
-.chat.chat-start
-  .chat-image.avatar
-    .w-10.rounded-full
-      = link_to("https://github.com/#{post.user.name}", target: '_blank', rel: 'noopener') do
-        = image_tag(post.user.image_url, alt: post.user.name)
-  .chat-header
-    span.text-xs
-      = post.user.name
-      | &nbsp;
-    time.text-xs.opacity-50
-      = l post.created_at, format: :short
-  .flex.items-end.gap-x-2
-    .chat-bubble
-      = post.content
-    - if post.created_by?(current_user)
-      = button_to '削除',
-                  group_post_path(group, post),
-                  method: :delete,
-                  data: { turbo_confirm: '本当に削除しますか？' },
-                  class: 'text-xs'
+= turbo_frame_tag post do
+  .chat.chat-start
+    .chat-image.avatar
+      .w-10.rounded-full
+        = link_to("https://github.com/#{post.user.name}", target: '_blank', rel: 'noopener') do
+          = image_tag(post.user.image_url, alt: post.user.name)
+    .chat-header
+      span.text-xs
+        = post.user.name
+        | &nbsp;
+      time.text-xs.opacity-50
+        = l post.created_at, format: :short
+    .flex.items-end.gap-x-2
+      .chat-bubble
+        = post.content
+      - if post.created_by?(current_user)
+        = button_to '削除',
+                    group_post_path(group, post),
+                    method: :delete,
+                    data: { turbo_confirm: '本当に削除しますか？' },
+                    class: 'text-xs'

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -13,9 +13,10 @@
     .flex.items-end.gap-x-2
       .chat-bubble
         = post.content
-      - if post.created_by?(current_user)
-        = button_to '削除',
-                    group_post_path(group, post),
-                    method: :delete,
-                    data: { turbo_confirm: '本当に削除しますか？' },
-                    class: 'text-xs'
+      = turbo_frame_tag "delete_button_#{post.id}" do
+        - if post.created_by?(current_user)
+          = button_to '削除',
+                      group_post_path(group, post),
+                      method: :delete,
+                      data: { turbo_confirm: '本当に削除しますか？' },
+                      class: 'text-xs'

--- a/app/views/posts/create.turbo_stream.slim
+++ b/app/views/posts/create.turbo_stream.slim
@@ -1,3 +1,3 @@
 = turbo_stream.append 'posts', partial: 'posts/post', locals: { post: @post, group: @group }
-= turbo_stream.update 'new_post', partial: 'posts/form', locals: { group: @group }
+= turbo_stream.replace 'new_post', partial: 'posts/form', locals: { group: @group }
 = turbo_stream.prepend 'flash', partial: 'application/flash'

--- a/app/views/posts/create.turbo_stream.slim
+++ b/app/views/posts/create.turbo_stream.slim
@@ -1,0 +1,3 @@
+= turbo_stream.append 'posts', partial: 'posts/post', locals: { post: @post, group: @group }
+= turbo_stream.update 'new_post', partial: 'posts/form', locals: { group: @group }
+= turbo_stream.prepend 'flash', partial: 'application/flash'

--- a/app/views/posts/create.turbo_stream.slim
+++ b/app/views/posts/create.turbo_stream.slim
@@ -1,3 +1,2 @@
-= turbo_stream.append 'posts', partial: 'posts/post', locals: { post: @post, group: @group }
 = turbo_stream.replace 'new_post', partial: 'posts/form', locals: { group: @group }
 = turbo_stream.prepend 'flash', partial: 'application/flash'

--- a/app/views/posts/destroy.turbo_stream.slim
+++ b/app/views/posts/destroy.turbo_stream.slim
@@ -1,2 +1,1 @@
-= turbo_stream.remove @post
 = turbo_stream.prepend 'flash', partial: 'application/flash'

--- a/app/views/posts/destroy.turbo_stream.slim
+++ b/app/views/posts/destroy.turbo_stream.slim
@@ -1,0 +1,2 @@
+= turbo_stream.remove @post
+= turbo_stream.prepend 'flash', partial: 'application/flash'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,6 +64,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Turbo::TestAssertions, type: :request
+  config.include Turbo::Broadcastable::TestHelper, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -109,6 +109,9 @@ RSpec.describe 'Posts', type: :system do
           expect(page).to have_content '投稿が作成されました'
           expect(page).to have_content 'テストコメント'
           expect(page).not_to have_content 'まだ投稿はありません。'
+          within('.chat') do
+            expect(page).to have_button '削除'
+          end
         end.to change(Post, :count).by(1)
 
         expect(page).to have_current_path(group_path(group))

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -152,33 +152,75 @@ RSpec.describe 'Posts', type: :system do
         expect(page).to have_current_path(group_path(group))
       end
     end
+
+    context 'when creating a post' do
+      it 'display the creates post and does not display the post delete button in a different session' do
+        visit group_path(group)
+        expect(page).to have_content 'まだ投稿はありません。'
+
+        using_session('post creator session') do
+          login_as(user)
+          visit group_path(group)
+          fill_in 'post_content', with: 'テストコメント'
+          click_button '投稿を作成する'
+        end
+
+        # reverts to different session
+        expect(page).to have_content 'テストコメント'
+        expect(page).not_to have_content 'まだ投稿はありません。'
+        expect(page).not_to have_content '投稿が作成されました'
+        within('.chat') do
+          expect(page).not_to have_button '削除'
+        end
+      end
+    end
   end
 
   describe 'deleting a post' do
     let(:post) { create(:post, group:) }
 
-    before do
-      login_as(post.user)
-    end
+    context 'when post owner deletes a post' do
+      it 'deletes a post' do
+        login_as(post.user)
+        visit group_path(group)
+        expect(page).to have_content post.content
+        expect(page).not_to have_content 'まだ投稿はありません。'
 
-    it 'deletes a post' do
-      visit group_path(group)
-      expect(page).to have_content post.content
-      expect(page).not_to have_content 'まだ投稿はありません。'
+        expect do
+          accept_confirm do
+            within('.chat') do
+              click_button '削除'
+            end
+          end
 
-      expect do
-        accept_confirm do
-          within('.chat') do
-            click_button '削除'
+          expect(page).to have_content '投稿が削除されました'
+          expect(page).not_to have_content post.content
+          expect(page).to have_content 'まだ投稿はありません。'
+        end.to change(Post, :count).by(-1)
+
+        expect(page).to have_current_path(group_path(group))
+      end
+
+      it 'does not display the deleted post in a different session' do
+        visit group_path(group)
+        expect(page).to have_content post.content
+        expect(page).not_to have_content 'まだ投稿はありません。'
+
+        using_session('post owner session') do
+          login_as(post.user)
+          visit group_path(group)
+          accept_confirm do
+            within('.chat') do
+              click_button '削除'
+            end
           end
         end
 
-        expect(page).to have_content '投稿が削除されました'
+        # reverts to different session
         expect(page).not_to have_content post.content
         expect(page).to have_content 'まだ投稿はありません。'
-      end.to change(Post, :count).by(-1)
-
-      expect(page).to have_current_path(group_path(group))
+        expect(page).not_to have_content '投稿が削除されました'
+      end
     end
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -101,12 +101,14 @@ RSpec.describe 'Posts', type: :system do
 
         click_button 'サインアップ / ログインをして投稿を作成する'
         expect(page).to have_current_path(group_path(group))
+        expect(page).to have_content 'まだ投稿はありません。'
 
         expect do
           fill_in 'post_content', with: 'テストコメント'
           click_button '投稿を作成する'
           expect(page).to have_content '投稿が作成されました'
           expect(page).to have_content 'テストコメント'
+          expect(page).not_to have_content 'まだ投稿はありません。'
         end.to change(Post, :count).by(1)
 
         expect(page).to have_current_path(group_path(group))
@@ -159,6 +161,7 @@ RSpec.describe 'Posts', type: :system do
     it 'deletes a post' do
       visit group_path(group)
       expect(page).to have_content post.content
+      expect(page).not_to have_content 'まだ投稿はありません。'
 
       expect do
         accept_confirm do
@@ -169,6 +172,7 @@ RSpec.describe 'Posts', type: :system do
 
         expect(page).to have_content '投稿が削除されました'
         expect(page).not_to have_content post.content
+        expect(page).to have_content 'まだ投稿はありません。'
       end.to change(Post, :count).by(-1)
 
       expect(page).to have_current_path(group_path(group))


### PR DESCRIPTION
## Issue
- #82 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [x] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [x] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- postの作成/削除をリアルタイム更新できるようにした。

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [Turbo: The speed of a single-page web application without having to write any JavaScript.](https://turbo.hotwired.dev/)
- [hotwired/turbo](https://github.com/hotwired/turbo)
- [hotwired/turbo-rails](http://github.com/hotwired/turbo-rails)
- [Learn Hotwire and Turbo with a free Rails 7 tutorial](https://www.hotrails.dev/turbo-rails)
- [猫でもわかるHotwire入門 Turbo編](https://zenn.dev/shita1112/books/cat-hotwire-turbo)
- [Active Record コールバック - 11.2 after_commitコールバックのエイリアス- Railsガイド](https://railsguides.jp/active_record_callbacks.html#after-commit%E3%82%B3%E3%83%BC%E3%83%AB%E3%83%90%E3%83%83%E3%82%AF%E3%81%AE%E3%82%A8%E3%82%A4%E3%83%AA%E3%82%A2%E3%82%B9)
- [Active Job の基礎 - Railsガイド](https://railsguides.jp/active_job_basics.html)
- [Action Cable の概要 - Railsガイド](https://railsguides.jp/action_cable_overview.html)

## 動作確認方法
1. `feat/#82/add-hotwire-to-post`をローカルに取り込む
1. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
1. 任意のユーザでログインし、任意のグループ詳細ページ(`/groups/{ID}`)にアクセス(ウィンドウ1)
1. シークレットモードで新しいウィンドウを開き、同じグループ詳細ページにアクセス(ウィンドウ2)
1. ウィンドウ1でpostを作成する
1. ウィンドウ1で作成したpostがウィンドウ2にも表示されることを確認する(ウィンドウ2に表示されたpostには削除ボタンが表示されていないことも確認する)
1. ウィンドウ1でpostを削除する
1. ウィンドウ1で削除したpostがウィンドウ2でも表示されないことを確認する

## スクリーンショット
### 変更前
![before](https://github.com/user-attachments/assets/84cba875-5c34-46d7-8bed-296e1609c177)

### 変更後
![after](https://github.com/user-attachments/assets/8e684f7d-f96a-4924-b163-7c6cf26e15a5)