### PR TITLE
「ユーザ退会時にユーザに紐づくPostを削除する」実装に統一した

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Post < ApplicationRecord
-  belongs_to :user, optional: true
+  belongs_to :user
   belongs_to :group
 
   validates :content, length: { maximum: 2000 }, presence: true

--- a/db/migrate/20250211140722_change_user_id_null_constraint_on_posts.rb
+++ b/db/migrate/20250211140722_change_user_id_null_constraint_on_posts.rb
@@ -1,0 +1,5 @@
+class ChangeUserIdNullConstraintOnPosts < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :posts, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_20_005845) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_11_140722) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_005845) do
   end
 
   create_table "posts", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.bigint "group_id", null: false
     t.text "content", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
## Issue
- #100 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [ ] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- `Posts`テーブルの`user_id`カラムにNOT NULL制約を追加した
- `app/models/post.rb`の`belongs_to :user`の`optional: true`を削除した


## 参考
<!-- 参考記事, 関連PR・issue  -->
- [ActiveRecord::ConnectionAdapters::SchemaStatements#change_column_null](https://api.rubyonrails.org/v8.0/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_column_null)
- https://github.com/djkazunoko/nijikai-go/pull/81#discussion_r1817430424
- https://github.com/djkazunoko/nijikai-go/pull/81#discussion_r1817432170

## 動作確認方法
アプリケーションの動作に影響はありません。
