### PR TITLE
参加者一覧をモーダル表示できるようにした

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  DISPLAYABLE_PARTICIPANT_ICONS_COUNT = 3
+
+  def displayable_participant_icons_count
+    DISPLAYABLE_PARTICIPANT_ICONS_COUNT
+  end
 end

--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -15,13 +15,16 @@
     p 募集内容
     p = group.details
 
-  .border-t.pt-4
+  .border-t.pt-4.participants
     .flex.justify-between.items-center.mb-4
       p 参加者
       .flex.items-center.space-x-4
-        - tickets.each do |ticket|
+        - tickets.first(displayable_participant_icons_count).each do |ticket|
           = link_to("https://github.com/#{ticket.user.name}", target: '_blank', rel: 'noopener') do
             = image_tag(ticket.user.image_url, class: 'w-10 h-10 rounded-full')
+        - if tickets.size > displayable_participant_icons_count
+          .flex.items-center.justify-center.w-10.h-10.rounded-full.bg-gray-200.text-gray-700.additional-participants-count
+            p = "+#{tickets.size - displayable_participant_icons_count}"
         p = "#{tickets.count} / #{group.capacity}人"
     = link_to '参加者一覧を見る', '#', class: 'block w-full text-center bg-blue-500 hover:bg-blue-600 text-white py-2 rounded-lg'
 

--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -26,8 +26,9 @@
           .flex.items-center.justify-center.w-10.h-10.rounded-full.bg-gray-200.text-gray-700.additional-participants-count
             p = "+#{tickets.size - displayable_participant_icons_count}"
         p = "#{tickets.count} / #{group.capacity}人"
-    button.block.w-full.text-center.bg-blue-500.hover:bg-blue-600.text-white.py-2.rounded-lg onclick="participant_list.showModal()"
-      | 参加者一覧を見る
+    - if tickets.any?
+      button.block.w-full.text-center.bg-blue-500.hover:bg-blue-600.text-white.py-2.rounded-lg onclick="participant_list.showModal()"
+        | 参加者一覧を見る
 
   .flex.justify-between.items-center.border-t.pt-4
     p 会場

--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -26,7 +26,8 @@
           .flex.items-center.justify-center.w-10.h-10.rounded-full.bg-gray-200.text-gray-700.additional-participants-count
             p = "+#{tickets.size - displayable_participant_icons_count}"
         p = "#{tickets.count} / #{group.capacity}人"
-    = link_to '参加者一覧を見る', '#', class: 'block w-full text-center bg-blue-500 hover:bg-blue-600 text-white py-2 rounded-lg'
+    button.block.w-full.text-center.bg-blue-500.hover:bg-blue-600.text-white.py-2.rounded-lg onclick="participant_list.showModal()"
+      | 参加者一覧を見る
 
   .flex.justify-between.items-center.border-t.pt-4
     p 会場
@@ -35,3 +36,18 @@
   .flex.justify-between.items-center.border-t.pt-4
     p 会計方法
     p = group.payment_method
+
+dialog#participant_list.modal
+  .modal-box.w-11/12.max-w-5xl
+    h3.text-lg.font-bold 参加者一覧
+    .py-4
+      - tickets.each do |ticket|
+        .flex.items-center.space-x-4.mb-2
+          = link_to("https://github.com/#{ticket.user.name}", target: '_blank', rel: 'noopener') do
+            = image_tag(ticket.user.image_url, class: 'w-10 h-10 rounded-full')
+          p = ticket.user.name
+    .modal-action
+      form method="dialog"
+        button.btn 閉じる
+  form.modal-backdrop method="dialog"
+    button close

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-users_data = [
-  { provider: 'github', uid: '1111', name: 'user1', image_url: 'https://picsum.photos/id/0/200' },
-  { provider: 'github', uid: '2222', name: 'user2', image_url: 'https://picsum.photos/id/20/200' },
-  { provider: 'github', uid: '3333', name: 'user3', image_url: 'https://picsum.photos/id/28/200' }
-]
+users_data = (1..50).map do |i|
+  { provider: 'github', uid: i.to_s, name: "user#{i}", image_url: "https://picsum.photos/id/#{i}/200" }
+end
 
 users = users_data.map { |user_data| User.create!(user_data) }
 
@@ -12,7 +10,8 @@ groups_data = [
   { name: 'みんなで飲みましょう!!', hashtag: 'rubykaigi', details: '誰でも参加OK!!', capacity: 2, location: '未定', payment_method: '割り勘', owner_id: users[0].id },
   { name: 'Railsの話がしたい', hashtag: 'kaigionrails', details: 'サシで話したい', capacity: 1, location: '未定', payment_method: '奢ります', owner_id: users[1].id },
   { name: 'Gather! Rubyists!', hashtag: 'rubyworld', details: 'Anyone who loves Ruby is welcome to join', capacity: 10, location: 'Somewhere in Japan',
-    payment_method: 'split bill', owner_id: users[2].id }
+    payment_method: 'split bill', owner_id: users[2].id },
+  { name: '大規模な飲み会', hashtag: 'bigparty', details: 'みんなで楽しく飲みましょう！', capacity: 100, location: '未定', payment_method: '割り勘', owner_id: users[0].id }
 ]
 
 groups = groups_data.map { |group_data| Group.create!(group_data) }
@@ -21,9 +20,12 @@ Ticket.create!(user: users[1], group: groups[0])
 Ticket.create!(user: users[2], group: groups[0])
 Ticket.create!(user: users[0], group: groups[2])
 Ticket.create!(user: users[1], group: groups[2])
+(2..50).each do |i|
+  Ticket.create!(user: users[i - 1], group: groups[3])
+end
 
 groups.first(2).each do |group|
-  users.each do |user|
+  users.first(10).each do |user|
     Post.create!(user:, group:, content: "Hello! by #{user.name}")
   end
 end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -127,6 +127,19 @@ RSpec.describe 'Groups', type: :system do
           expect(page).to have_css('.additional-participants-count', text: '+1')
         end
       end
+
+      it 'displays all participant icons and names in the modal' do
+        visit group_path(group_with_4_participants)
+        click_button '参加者一覧を見る'
+
+        within('dialog#participant_list.modal') do
+          group_with_4_participants.tickets.each do |ticket|
+            expect(page).to have_css("a[href='https://github.com/#{ticket.user.name}']")
+            expect(page).to have_css("img[src='#{ticket.user.image_url}']")
+            expect(page).to have_content(ticket.user.name)
+          end
+        end
+      end
     end
   end
 

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -97,6 +97,37 @@ RSpec.describe 'Groups', type: :system do
         expect(page).not_to have_button('削除')
       end
     end
+
+    context 'when group has participants' do
+      let(:group_with_2_participants) { create(:group) }
+      let(:group_with_4_participants) { create(:group) }
+
+      before do
+        create_list(:ticket, 2, group: group_with_2_participants)
+        create_list(:ticket, 4, group: group_with_4_participants)
+      end
+
+      it 'displays all participant icons when there are 3 or fewer participants' do
+        visit group_path(group_with_2_participants)
+        within('.participants') do
+          group_with_2_participants.tickets.each do |ticket|
+            expect(page).to have_css("a[href='https://github.com/#{ticket.user.name}']")
+          end
+          expect(page).not_to have_css('.additional-participants-count')
+        end
+      end
+
+      it 'displays up to 3 participant icons when there are more than 3 participants' do
+        visit group_path(group_with_4_participants)
+        within('.participants') do
+          group_with_4_participants.tickets.first(3).each do |ticket|
+            expect(page).to have_css("a[href='https://github.com/#{ticket.user.name}']")
+          end
+          expect(page).not_to have_css("a[href='https://github.com/#{group_with_4_participants.tickets.last.user.name}']")
+          expect(page).to have_css('.additional-participants-count', text: '+1')
+        end
+      end
+    end
   end
 
   describe 'new group page' do

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe 'Groups', type: :system do
       expect(page).to have_content group.name
       expect(page).to have_content group.details
       expect(page).to have_content group.capacity
+      expect(page).not_to have_button('参加者一覧を見る')
       expect(page).to have_content group.location
       expect(page).to have_content group.payment_method
     end


### PR DESCRIPTION
## Issue
- #105 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [x] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- 参加者一覧をモーダル表示できるようにした
  - daisyUIのModalコンポーネントを使用
- 画面幅が狭い時を考慮し、参加者のアイコンの表示数を最大で3つまでに制限した
- 参加者がいない時は「参加者一覧を見る」ボタンを非表示にした
- seedデータを追加した

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [Tailwind Modal Component — Tailwind CSS Components](https://daisyui.com/components/modal/)

## 動作確認方法
1. `feat/#105/modal-participant-list`をローカルに取り込む
1. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
1. 参加者がいないグループの詳細ページ(`/groups/{ID}`)にアクセス
1. 「参加者一覧を見る」ボタンが表示されていないことを確認する
1. 参加者がいるグループの詳細ページ(`/groups/{ID}`)にアクセス
1. 「参加者一覧を見る」ボタンを選択し、参加者一覧がモーダル表示されることを確認する

## スクリーンショット
### 変更前
参加者がいない時
![before_no_participants](https://github.com/user-attachments/assets/02bc40d3-3c5a-44f9-acf5-a9ef15aac9b1)

参加者がいる時
![before_participants](https://github.com/user-attachments/assets/14842be7-c7c7-42ea-8e55-9da8ac739895)


### 変更後
参加者がいない時
![after_no_participants](https://github.com/user-attachments/assets/9202d8b1-03f0-47db-8193-dda910fd86f9)

参加者がいる時
![after_participants](https://github.com/user-attachments/assets/f5c5e5c2-09e3-4034-b618-59550665bee2)

モーダル表示
![after_modal](https://github.com/user-attachments/assets/f34a2c67-9941-45f4-885f-77da8b136a14)
