### PR TITLE
Groupsテーブルのnameカラムを削除した

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -17,7 +17,6 @@ class GroupsController < ApplicationController
 
   def new
     @group = current_user.groups.new(
-      name: 'みんなで飲みましょう!!',
       details: '誰でも参加OK!!',
       capacity: 10,
       location: '未定',

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,7 +6,6 @@ class Group < ApplicationRecord
   has_many :posts, dependent: :destroy
 
   validates :hashtag, presence: true, length: { maximum: 50 }
-  validates :name, presence: true, length: { maximum: 50 }
   validates :details, presence: true, length: { maximum: 2000 }
   validates :capacity, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :location, presence: true, length: { maximum: 100 }

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -13,12 +13,6 @@
       | 現在参加しているイベントのハッシュタグを入力してください。
 
   .mb-4
-    = form.label :name, style: 'display: block'
-    = form.text_field :name
-    p.text-gray-400.text-sm
-      | 2次会のテーマを含む名前がおすすめです。
-
-  .mb-4
     = form.label :details, style: 'display: block'
     = form.text_area :details
     p.text-gray-400.text-sm

--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -8,10 +8,6 @@
     p = "#{group.hashtag} の2次会"
 
   .flex.justify-between.items-center.border-t.pt-4
-    p グループ名
-    p = group.name
-
-  .flex.justify-between.items-center.border-t.pt-4
     p 募集内容
     p = group.details
 

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -26,8 +26,7 @@ p.mb-4
           = image_tag(group.owner.image_url, class: 'w-12 h-12 rounded-full')
         .flex-1.ml-4
           p.font-bold = "#{group.hashtag} の2次会"
-          p.text-lg.font-semibold = group.name
-          p.text-sm.text-gray-600 = group.details
+          p.text-lg.font-semibold = group.details
           .flex.justify-between.items-center.mt-2
             p.text-sm.text-gray-600 会場: #{group.location}
             p.text-sm.text-gray-600 = "#{group.tickets.count} / #{group.capacity}人"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,7 +5,6 @@ ja:
     attributes:
       group:
         hashtag: イベントのハッシュタグ
-        name: 2次会グループ名
         details: 募集内容
         capacity: 定員
         location: 会場

--- a/db/migrate/20250220130400_remove_name_from_groups.rb
+++ b/db/migrate/20250220130400_remove_name_from_groups.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromGroups < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :groups, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_11_140722) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_20_130400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "groups", force: :cascade do |t|
     t.string "hashtag", null: false
-    t.string "name", null: false
     t.text "details", null: false
     t.integer "capacity", null: false
     t.string "location", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,11 +7,11 @@ end
 users = users_data.map { |user_data| User.create!(user_data) }
 
 groups_data = [
-  { name: 'みんなで飲みましょう!!', hashtag: 'rubykaigi', details: '誰でも参加OK!!', capacity: 2, location: '未定', payment_method: '割り勘', owner_id: users[0].id },
-  { name: 'Railsの話がしたい', hashtag: 'kaigionrails', details: 'サシで話したい', capacity: 1, location: '未定', payment_method: '奢ります', owner_id: users[1].id },
-  { name: 'Gather! Rubyists!', hashtag: 'rubyworld', details: 'Anyone who loves Ruby is welcome to join', capacity: 10, location: 'Somewhere in Japan',
+  { hashtag: 'rubykaigi', details: '誰でも参加OK!!', capacity: 2, location: '未定', payment_method: '割り勘', owner_id: users[0].id },
+  { hashtag: 'kaigionrails', details: 'サシで話したい', capacity: 1, location: '未定', payment_method: '奢ります', owner_id: users[1].id },
+  { hashtag: 'rubyworld', details: 'Anyone who loves Ruby is welcome to join', capacity: 10, location: 'Somewhere in Japan',
     payment_method: 'split bill', owner_id: users[2].id },
-  { name: '大規模な飲み会', hashtag: 'bigparty', details: 'みんなで楽しく飲みましょう！', capacity: 100, location: '未定', payment_method: '割り勘', owner_id: users[0].id }
+  { hashtag: 'bigparty', details: 'みんなで楽しく飲みましょう！', capacity: 100, location: '未定', payment_method: '割り勘', owner_id: users[0].id }
 ]
 
 groups = groups_data.map { |group_data| Group.create!(group_data) }

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :group do
     hashtag { 'rubykaigi' }
-    name { 'みんなで飲みましょう!!' }
     details { '誰でも参加OK!!' }
     capacity { 10 }
     location { '未定' }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe Group, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:hashtag) }
-    it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:details) }
     it { is_expected.to validate_presence_of(:capacity) }
     it { is_expected.to validate_presence_of(:location) }
@@ -13,7 +12,6 @@ RSpec.describe Group, type: :model do
     it { is_expected.to validate_numericality_of(:capacity).only_integer }
     it { is_expected.to validate_numericality_of(:capacity).is_greater_than(0) }
     it { is_expected.to validate_length_of(:hashtag).is_at_most(50) }
-    it { is_expected.to validate_length_of(:name).is_at_most(50) }
     it { is_expected.to validate_length_of(:details).is_at_most(2000) }
     it { is_expected.to validate_length_of(:location).is_at_most(100) }
     it { is_expected.to validate_length_of(:payment_method).is_at_most(50) }

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe '/groups', type: :request do
   end
 
   describe 'PATCH /groups/:id' do
-    let(:new_attributes) { attributes_for(:group, name: 'New Group Name') }
+    let(:new_attributes) { attributes_for(:group, details: 'New Group Details') }
 
     context 'when logged in user is the group owner' do
       before do
@@ -121,7 +121,7 @@ RSpec.describe '/groups', type: :request do
       it 'updates the group with valid parameters' do
         patch group_url(group), params: { group: new_attributes }
         group.reload
-        expect(group.name).to eq 'New Group Name'
+        expect(group.details).to eq 'New Group Details'
         expect(response).to redirect_to(group_url(group))
       end
 

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_content '2次会グループ一覧'
         expect(page).to have_css("img[src='#{group.owner.image_url}']")
         expect(page).to have_content group.hashtag
-        expect(page).to have_content group.name
         expect(page).to have_content group.details
         expect(page).to have_content group.capacity
         expect(page).to have_content group.location
@@ -57,7 +56,6 @@ RSpec.describe 'Groups', type: :system do
       visit group_path(group)
       expect(page).to have_link(href: "https://github.com/#{group.owner.name}")
       expect(page).to have_content group.hashtag
-      expect(page).to have_content group.name
       expect(page).to have_content group.details
       expect(page).to have_content group.capacity
       expect(page).not_to have_button('参加者一覧を見る')
@@ -158,7 +156,6 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_current_path(new_group_path)
         expect(page).to have_content '2次会グループを作成'
         expect(page).to have_field 'イベントのハッシュタグ'
-        expect(page).to have_field '2次会グループ名', with: 'みんなで飲みましょう!!'
         expect(page).to have_field '募集内容', with: '誰でも参加OK!!'
         expect(page).to have_field '定員', with: 10
         expect(page).to have_field '会場', with: '未定'
@@ -190,7 +187,6 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_current_path(new_group_path)
         expect do
           fill_in 'イベントのハッシュタグ', with: 'rubykaigi'
-          fill_in '2次会グループ名', with: 'みんなで飲みましょう!!'
           fill_in '募集内容', with: '誰でも参加OK!!'
           fill_in '定員', with: 10
           fill_in '会場', with: '未定'
@@ -209,7 +205,6 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_current_path(new_group_path)
         expect do
           fill_in 'イベントのハッシュタグ', with: ''
-          fill_in '2次会グループ名', with: 'みんなで飲みましょう!!'
           fill_in '募集内容', with: '誰でも参加OK!!'
           fill_in '定員', with: 10
           fill_in '会場', with: '未定'
@@ -237,7 +232,6 @@ RSpec.describe 'Groups', type: :system do
         visit edit_group_path(group)
         expect(page).to have_content '2次会グループを編集'
         expect(page).to have_field 'イベントのハッシュタグ', with: group.hashtag
-        expect(page).to have_field '2次会グループ名', with: group.name
         expect(page).to have_field '募集内容', with: group.details
         expect(page).to have_field '定員', with: group.capacity
         expect(page).to have_field '会場', with: group.location


### PR DESCRIPTION
## Issue
- #113 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
Groupsテーブルのnameカラムの削除に伴い以下の修正をした。
- Groupモデルのname属性のバリデーションを削除した
- GroupsController#newでname属性を設定しないように変更した
- グループ作成フォームのgroup.name入力欄を削除した
- グループ詳細ページのgroup.nameの表示を削除した
- グループ一覧ページのgroup.nameの表示を削除した
- 関連するテストを修正した
- group.nameの日本語訳を削除した
- seedデータを修正した

## 動作確認方法
1. `feat/#113/remove-name-column-from-groups`をローカルに取り込む
1. `bin/rails db:migrate`を実行する
1. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
1. グループ作成ページ(`groups/new`)にアクセスし、フォームに「2次会グループ名」入力欄がないことを確認する
1. グループ詳細ページ(`groups/{ID}`)にアクセスし、「グループ名」が表示されていないことを確認する
1. グループ一覧ページ(`groups/`)にアクセスし、グループ名(`group.name`)の内容が表示されていないことを確認する

## スクリーンショット
### 変更前
`/groups`
<img width="655" alt="before_index" src="https://github.com/user-attachments/assets/45a4a920-ee98-449d-bbea-d97f68ce4481" />

`/groups/{ID}`
<img width="655" alt="before_show" src="https://github.com/user-attachments/assets/c62ff54b-caed-4c85-83b9-2b3021b6a380" />

`/groups/new`
<img width="655" alt="before_new" src="https://github.com/user-attachments/assets/9fbda912-a6ed-466c-9cb8-def10f498437" />

### 変更後
`/groups`
<img width="655" alt="after_index" src="https://github.com/user-attachments/assets/6eb0253a-d8d5-4a22-8599-12350c289b75" />

`/groups/{ID}`
<img width="655" alt="after_show" src="https://github.com/user-attachments/assets/2d66bb8a-b820-4aa5-bb0a-1ea700e672c2" />

`/groups/new`
<img width="655" alt="after_new" src="https://github.com/user-attachments/assets/cb60a9a9-cd98-49fa-bc1a-65d2ba412e1f" />
