### PR TITLE
グループ詳細ページのデザインを修正した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 gem 'active_decorator'
+gem 'font-awesome-sass', '~> 6.7', '>= 6.7.2'
 gem 'omniauth'
 gem 'omniauth-github'
 gem 'omniauth-rails_csrf_protection'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,14 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86-linux-gnu)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
+    font-awesome-sass (6.7.2)
+      sassc (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -315,6 +323,8 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     selenium-webdriver (4.18.1)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
@@ -398,6 +408,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  font-awesome-sass (~> 6.7, >= 6.7.2)
   html2slim-ruby3
   importmap-rails
   jbuilder

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -13,3 +13,4 @@
  *= require_tree .
  *= require_self
  */
+@import "font-awesome";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  DISPLAYABLE_PARTICIPANT_ICONS_COUNT = 3
+  DISPLAYABLE_PARTICIPANT_ICONS_COUNT = 5
 
   def displayable_participant_icons_count
     DISPLAYABLE_PARTICIPANT_ICONS_COUNT

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -23,6 +23,10 @@ class Group < ApplicationRecord
     tickets.count >= capacity
   end
 
+  def remaining_slots
+    capacity - tickets.count
+  end
+
   private
 
   def capacity_cannot_be_less_than_participants

--- a/app/views/application/_footer.html.slim
+++ b/app/views/application/_footer.html.slim
@@ -1,8 +1,9 @@
-footer
-  ul.flex.justify-center.space-x-8.pt-4.pb-4
+footer.bg-white.border-t
+  ul.flex.justify-center.items-center.space-x-8.pt-4.pb-4
     li.text-xs.hover:underline.hover:text-gray-400 = link_to '利用規約', tos_path
     li.text-xs.hover:underline.hover:text-gray-400 = link_to 'プライバシーポリシー', pp_path
-    li.text-xs.hover:underline.hover:text-gray-400 = link_to 'GitHub', 'https://github.com/djkazunoko/nijikai-go', target: '_blank', rel: 'noopener'
+    li.text-xl.hover:underline.hover:text-gray-400 = link_to 'https://github.com/djkazunoko/nijikai-go', target: '_blank', rel: 'noopener' do
+      i.fa-brands.fa-github
   p.text-center.text-xs.pb-4
     = "© #{Time.current.year} "
     = link_to 'djkazunoko', 'https://x.com/djkazunoko', target: '_blank', rel: 'noopener', class: 'hover:underline hover:text-gray-400'

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -1,4 +1,4 @@
-.navbar.bg-base-100
+.navbar.bg-base-100.border-b
   .flex-1
     = link_to '2次会GO！',
               root_path,

--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -1,20 +1,17 @@
-.p-6.shadow-md.space-y-6
-  .flex.justify-between.items-center
-    .flex.items-center.space-x-4
-      div
-        p 主催者
-        = link_to("https://github.com/#{group.owner.name}", target: '_blank', rel: 'noopener') do
-          = image_tag(group.owner.image_url, class: 'w-12 h-12 rounded-full')
-    p = "#{group.hashtag} の2次会"
+.group-details.m-4
+  .flex.items-center.border-b.py-2
+    = link_to("https://github.com/#{group.owner.name}", target: '_blank', rel: 'noopener') do
+      = image_tag(group.owner.image_url, class: 'w-10 h-10 rounded-full hover:opacity-50 mr-2')
+    p.text-lg.font-bold
+      = link_to "##{group.hashtag}", "https://x.com/search?q=%23#{group.hashtag}", target: '_blank', rel: 'noopener', class: 'text-blue-700 hover:text-blue-500 hover:underline'
+      | &nbsp;の2次会
 
-  .flex.justify-between.items-center.border-t.pt-4
-    p 募集内容
-    p = group.details
+  p.text-2xl.font-bold.border-b.py-2 = group.details
 
-  .flex.justify-between.items-center.border-t.pt-4
-    p 会場
+  .flex.items-center.border-b.py-2
+    i.fa-solid.fa-location-dot.mr-2
     p = group.location
 
-  .flex.justify-between.items-center.border-t.pt-4
-    p 会計方法
+  .flex.items-center.border-b.py-2
+    i.fa-solid.fa-sack-dollar.mr-2
     p = group.payment_method

--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -11,21 +11,6 @@
     p 募集内容
     p = group.details
 
-  .border-t.pt-4.participants
-    .flex.justify-between.items-center.mb-4
-      p 参加者
-      .flex.items-center.space-x-4
-        - tickets.first(displayable_participant_icons_count).each do |ticket|
-          = link_to("https://github.com/#{ticket.user.name}", target: '_blank', rel: 'noopener') do
-            = image_tag(ticket.user.image_url, class: 'w-10 h-10 rounded-full')
-        - if tickets.size > displayable_participant_icons_count
-          .flex.items-center.justify-center.w-10.h-10.rounded-full.bg-gray-200.text-gray-700.additional-participants-count
-            p = "+#{tickets.size - displayable_participant_icons_count}"
-        p = "#{tickets.count} / #{group.capacity}人"
-    - if tickets.any?
-      button.block.w-full.text-center.bg-blue-500.hover:bg-blue-600.text-white.py-2.rounded-lg onclick="participant_list.showModal()"
-        | 参加者一覧を見る
-
   .flex.justify-between.items-center.border-t.pt-4
     p 会場
     p = group.location
@@ -33,18 +18,3 @@
   .flex.justify-between.items-center.border-t.pt-4
     p 会計方法
     p = group.payment_method
-
-dialog#participant_list.modal
-  .modal-box.w-11/12.max-w-5xl
-    h3.text-lg.font-bold 参加者一覧
-    .py-4
-      - tickets.each do |ticket|
-        .flex.items-center.space-x-4.mb-2
-          = link_to("https://github.com/#{ticket.user.name}", target: '_blank', rel: 'noopener') do
-            = image_tag(ticket.user.image_url, class: 'w-10 h-10 rounded-full')
-          p = ticket.user.name
-    .modal-action
-      form method="dialog"
-        button.btn 閉じる
-  form.modal-backdrop method="dialog"
-    button close

--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -1,9 +1,9 @@
-.group-details.m-4
+.group-details.mx-4
   .flex.items-center.border-b.py-2
     = link_to("https://github.com/#{group.owner.name}", target: '_blank', rel: 'noopener') do
       = image_tag(group.owner.image_url, class: 'w-10 h-10 rounded-full hover:opacity-50 mr-2')
     p.text-lg.font-bold
-      = link_to "##{group.hashtag}", "https://x.com/search?q=%23#{group.hashtag}", target: '_blank', rel: 'noopener', class: 'text-blue-700 hover:text-blue-500 hover:underline'
+      = link_to "##{group.hashtag}", "https://x.com/search?q=%23#{group.hashtag}", target: '_blank', rel: 'noopener', class: 'text-blue-700 underline hover:text-blue-500 hover:no-underline'
       | &nbsp;の2次会
 
   p.text-2xl.font-bold.border-b.py-2 = group.details

--- a/app/views/groups/_participants.html.slim
+++ b/app/views/groups/_participants.html.slim
@@ -1,7 +1,7 @@
-.participants
+.participants.m-4
   .flex.justify-between.mb-2
     p.text-lg.font-bold = "参加者(#{tickets.count}名 / #{group.capacity}名)"
-    button.hover:underline.hover:text-gray-400 onclick="modal.showModal()"
+    button.text-blue-700.underline.hover:no-underline.hover:text-blue-500 onclick="modal.showModal()"
       | すべて見る
   .flex.justify-around
     - tickets.first(displayable_participant_icons_count).each do |ticket|
@@ -15,7 +15,7 @@ dialog#modal.modal
       .flex.items-center.space-x-4.mb-2
         = link_to("https://github.com/#{ticket.user.name}", target: '_blank', rel: 'noopener') do
           = image_tag(ticket.user.image_url, class: 'w-10 h-10 rounded-full hover:opacity-50')
-        p = ticket.user.name
+        = link_to ticket.user.name, "https://github.com/#{ticket.user.name}", target: '_blank', rel: 'noopener', class: 'text-blue-700 underline hover:text-blue-500 hover:no-underline'
     .modal-action
       form method="dialog"
         button.btn 閉じる

--- a/app/views/groups/_participants.html.slim
+++ b/app/views/groups/_participants.html.slim
@@ -1,0 +1,23 @@
+.participants
+  .flex.justify-between.mb-2
+    p.text-lg.font-bold = "#{tickets.count}人の参加者"
+    button.hover:underline.hover:text-gray-400 onclick="modal.showModal()"
+      | すべて見る
+  .flex.justify-around
+    - tickets.first(displayable_participant_icons_count).each do |ticket|
+      = link_to("https://github.com/#{ticket.user.name}", target: '_blank', rel: 'noopener') do
+          = image_tag(ticket.user.image_url, class: 'w-10 h-10 rounded-full hover:opacity-50')
+
+dialog#modal.modal
+  .modal-box
+    p.text-lg.font-bold.mb-2 参加者一覧
+    - tickets.each do |ticket|
+      .flex.items-center.space-x-4.mb-2
+        = link_to("https://github.com/#{ticket.user.name}", target: '_blank', rel: 'noopener') do
+          = image_tag(ticket.user.image_url, class: 'w-10 h-10 rounded-full hover:opacity-50')
+        p = ticket.user.name
+    .modal-action
+      form method="dialog"
+        button.btn 閉じる
+  form.modal-backdrop method="dialog"
+    button

--- a/app/views/groups/_participants.html.slim
+++ b/app/views/groups/_participants.html.slim
@@ -1,6 +1,6 @@
 .participants
   .flex.justify-between.mb-2
-    p.text-lg.font-bold = "#{tickets.count}人の参加者"
+    p.text-lg.font-bold = "参加者(#{tickets.count}名 / #{group.capacity}名)"
     button.hover:underline.hover:text-gray-400 onclick="modal.showModal()"
       | すべて見る
   .flex.justify-around

--- a/app/views/groups/_participation.html.slim
+++ b/app/views/groups/_participation.html.slim
@@ -1,0 +1,27 @@
+.participation-action-items
+  - if ticket
+    .flex.flex-col.items-center.border.border-lime-500.bg-lime-100.rounded-lg.m-4.p-4
+      p.text-lime-700.mb-2 参加登録しています
+      = button_to '参加を取り消す',
+                  group_ticket_path(group, ticket),
+                  method: :delete,
+                  class: 'text-sm text-gray-400 underline hover:no-underline'
+  - elsif group.full_capacity?
+    p.text-center.text-red-700.border.border-red-500.bg-red-100.rounded-lg.m-4.p-4 定員に達したため参加できません
+  - elsif logged_in?
+    .flex.flex-col.items-center.border.border-blue-500.bg-blue-100.rounded-lg.m-4.p-4
+      p.text-sm.text-blue-700.mb-2 = "あと#{group.remaining_slots}名が参加できます"
+      .w-4/5
+        = button_to '2次会に参加する',
+                    group_tickets_path(group),
+                    data: { turbo: false },
+                    class: 'btn w-full text-white bg-blue-500 hover:bg-blue-700',
+                    id: 'participate-button'
+  - else
+    .flex.flex-col.items-center.border.border-blue-500.bg-blue-100.rounded-lg.m-4.p-4
+      p.text-sm.text-blue-700.mb-2 = "あと#{group.remaining_slots}名が参加できます"
+      .w-4/5
+        = button_to "/auth/github/?group_id=#{group.id}", data: { turbo: false }, class: 'btn w-full h-auto text-white leading-5 bg-blue-500 hover:bg-blue-700 py-2', id: 'signup-participate-button' do
+          | サインアップ / ログインをして
+          br
+          | 2次会に参加する

--- a/app/views/groups/_participation.html.slim
+++ b/app/views/groups/_participation.html.slim
@@ -1,15 +1,15 @@
-.participation-action-items
+.participation-action-items.m-4
   - if ticket
-    .flex.flex-col.items-center.border.border-lime-500.bg-lime-100.rounded-lg.m-4.p-4
+    .flex.flex-col.items-center.border.border-lime-500.bg-lime-100.rounded-lg.p-4
       p.text-lime-700.mb-2 参加登録しています
       = button_to '参加を取り消す',
                   group_ticket_path(group, ticket),
                   method: :delete,
                   class: 'text-sm text-gray-400 underline hover:no-underline'
   - elsif group.full_capacity?
-    p.text-center.text-red-700.border.border-red-500.bg-red-100.rounded-lg.m-4.p-4 定員に達したため参加できません
+    p.text-center.text-red-700.border.border-red-500.bg-red-100.rounded-lg.p-4 定員に達したため参加できません
   - elsif logged_in?
-    .flex.flex-col.items-center.border.border-blue-500.bg-blue-100.rounded-lg.m-4.p-4
+    .flex.flex-col.items-center.border.border-blue-500.bg-blue-100.rounded-lg.p-4
       p.text-sm.text-blue-700.mb-2 = "あと#{group.remaining_slots}名が参加できます"
       .w-4/5
         = button_to '2次会に参加する',
@@ -18,7 +18,7 @@
                     class: 'btn w-full text-white bg-blue-500 hover:bg-blue-700',
                     id: 'participate-button'
   - else
-    .flex.flex-col.items-center.border.border-blue-500.bg-blue-100.rounded-lg.m-4.p-4
+    .flex.flex-col.items-center.border.border-blue-500.bg-blue-100.rounded-lg.p-4
       p.text-sm.text-blue-700.mb-2 = "あと#{group.remaining_slots}名が参加できます"
       .w-4/5
         = button_to "/auth/github/?group_id=#{group.id}", data: { turbo: false }, class: 'btn w-full h-auto text-white leading-5 bg-blue-500 hover:bg-blue-700 py-2', id: 'signup-participate-button' do

--- a/app/views/groups/_share_button.html.slim
+++ b/app/views/groups/_share_button.html.slim
@@ -1,0 +1,4 @@
+.x-share-button.text-center.m-4
+  = link_to group.twitter_share_url, target: '_blank', rel: 'noopener', class: 'btn bg-black text-white w-full' do
+    i.fa-brands.fa-x-twitter
+    | で参加者を募集する

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -29,7 +29,7 @@
                   class: 'btn w-full'
 
 - if @tickets.any?
-  == render partial: 'groups/participants', locals: { tickets: @tickets }
+  == render partial: 'groups/participants', locals: { group: @group, tickets: @tickets }
 
 .mt-4
   = link_to 'Xでシェアして参加者を募集する',

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -18,8 +18,10 @@
       p.w-full.bg-red-100.text-red-700.p-4.rounded.text-center
         | 定員に達したため参加できません
     - elsif logged_in?
-      = form_with(url: group_tickets_path(@group), html: { class: 'w-full' }) do |form|
-        = form.submit 'この2次会グループに参加する', class: 'btn w-full'
+      = button_to 'この2次会グループに参加する',
+                  group_tickets_path(@group),
+                  data: { turbo: false },
+                  class: 'btn w-full'
     - else
       = button_to 'サインアップ / ログインをして2次会グループに参加',
                   "/auth/github/?group_id=#{@group.id}",

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -1,31 +1,33 @@
 = turbo_stream_from 'posts'
 = turbo_stream_from current_user
 
-.mb-4
-  == render partial: 'groups/group', locals: { group: @group, tickets: @tickets }
+== render partial: 'groups/group', locals: { group: @group, tickets: @tickets }
 
-div
-  - if @group.created_by?(current_user)
+- if @group.created_by?(current_user)
+  .owner-action-items
     = link_to '編集', edit_group_path(@group)
     = button_to '削除', @group, method: :delete, data: { turbo_confirm: '本当に削除しますか？' }
+- else
+  .participation-action-items
+    - if @ticket
+      = button_to '参加をキャンセルする',
+                  group_ticket_path(@group, @ticket),
+                  method: :delete,
+                  class: 'btn btn-error w-full'
+    - elsif @group.full_capacity?
+      p.w-full.bg-red-100.text-red-700.p-4.rounded.text-center
+        | 定員に達したため参加できません
+    - elsif logged_in?
+      = form_with(url: group_tickets_path(@group), html: { class: 'w-full' }) do |form|
+        = form.submit 'この2次会グループに参加する', class: 'btn w-full'
+    - else
+      = button_to 'サインアップ / ログインをして2次会グループに参加',
+                  "/auth/github/?group_id=#{@group.id}",
+                  data: { turbo: false },
+                  class: 'btn w-full'
 
-- unless @group.created_by?(current_user)
-  - if @ticket
-    = button_to '参加をキャンセルする',
-                group_ticket_path(@group, @ticket),
-                method: :delete,
-                class: 'btn btn-error w-full'
-  - elsif @group.full_capacity?
-    p.w-full.bg-red-100.text-red-700.p-4.rounded.text-center
-      | 定員に達したため参加できません
-  - elsif logged_in?
-    = form_with(url: group_tickets_path(@group), html: { class: 'w-full' }) do |form|
-      = form.submit 'この2次会グループに参加する', class: 'btn w-full'
-  - else
-    = button_to 'サインアップ / ログインをして2次会グループに参加',
-                "/auth/github/?group_id=#{@group.id}",
-                data: { turbo: false },
-                class: 'btn w-full'
+- if @tickets.any?
+  .participant-list
 
 .mt-4
   = link_to 'Xでシェアして参加者を募集する',

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -21,12 +21,7 @@
 
 == render partial: 'groups/share_button', locals: { group: @group }
 
-.p-4.my-4.shadow-md
-  p.mb-4 掲示板
-  #posts.overflow-y-auto.max-h-80
-    == render partial: 'posts/post', collection: @posts, locals: { group: @group }
-    .hidden.only:block
-      | まだ投稿はありません。
+== render partial: 'posts/posts', locals: { group: @group, posts: @posts }
 
 div
   - if logged_in?

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -19,11 +19,7 @@
 - if @tickets.any?
   == render partial: 'groups/participants', locals: { group: @group, tickets: @tickets }
 
-.mt-4
-  = link_to 'Xでシェアして参加者を募集する',
-            @group.twitter_share_url,
-            target: '_blank', rel: 'noopener',
-            class: 'btn w-full'
+== render partial: 'groups/share_button', locals: { group: @group }
 
 .p-4.my-4.shadow-md
   p.mb-4 掲示板

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -8,25 +8,7 @@
     = link_to '編集', edit_group_path(@group)
     = button_to '削除', @group, method: :delete, data: { turbo_confirm: '本当に削除しますか？' }
 - else
-  .participation-action-items
-    - if @ticket
-      = button_to '参加をキャンセルする',
-                  group_ticket_path(@group, @ticket),
-                  method: :delete,
-                  class: 'btn btn-error w-full'
-    - elsif @group.full_capacity?
-      p.w-full.bg-red-100.text-red-700.p-4.rounded.text-center
-        | 定員に達したため参加できません
-    - elsif logged_in?
-      = button_to 'この2次会グループに参加する',
-                  group_tickets_path(@group),
-                  data: { turbo: false },
-                  class: 'btn w-full'
-    - else
-      = button_to 'サインアップ / ログインをして2次会グループに参加',
-                  "/auth/github/?group_id=#{@group.id}",
-                  data: { turbo: false },
-                  class: 'btn w-full'
+  == render partial: 'groups/participation', locals: { group: @group, ticket: @ticket }
 
 - if @tickets.any?
   == render partial: 'groups/participants', locals: { group: @group, tickets: @tickets }

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -23,11 +23,11 @@
 
 == render partial: 'posts/posts', locals: { group: @group, posts: @posts }
 
-div
+.post-form.m-4
   - if logged_in?
     == render 'posts/form', group: @group
   - else
-    = button_to 'サインアップ / ログインをして投稿を作成する',
+    = button_to 'サインアップ / ログインをしてコメントする',
                 '/auth/github',
                 data: { turbo: false },
-                class: 'btn'
+                class: 'btn w-full'

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -4,9 +4,15 @@
 == render partial: 'groups/group', locals: { group: @group }
 
 - if @group.created_by?(current_user)
-  .owner-action-items
-    = link_to '編集', edit_group_path(@group)
-    = button_to '削除', @group, method: :delete, data: { turbo_confirm: '本当に削除しますか？' }
+  .owner-action-items.flex.justify-center.relative.m-4
+    = link_to edit_group_path(@group), class: 'btn w-2/5' do
+      i.fa-solid.fa-pen
+      | 内容修正
+    = button_to '削除する',
+                @group,
+                method: :delete,
+                data: { turbo_confirm: '本当に削除しますか？' },
+                class: 'text-sm text-gray-400 underline hover:text-red-500 hover:no-underline absolute right-0 bottom-0'
 - else
   == render partial: 'groups/participation', locals: { group: @group, ticket: @ticket }
 

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -1,7 +1,7 @@
 = turbo_stream_from 'posts'
 = turbo_stream_from current_user
 
-== render partial: 'groups/group', locals: { group: @group, tickets: @tickets }
+== render partial: 'groups/group', locals: { group: @group }
 
 - if @group.created_by?(current_user)
   .owner-action-items

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -27,7 +27,7 @@
                   class: 'btn w-full'
 
 - if @tickets.any?
-  .participant-list
+  == render partial: 'groups/participants', locals: { tickets: @tickets }
 
 .mt-4
   = link_to 'Xでシェアして参加者を募集する',

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html
+html.bg-gray-100
   head
     title
       | Nijikaigo
@@ -13,7 +13,7 @@ html
     script[src="https://cdn.tailwindcss.com"]
   body.max-w-screen-sm.mx-auto.min-h-screen.flex.flex-col
     = render 'application/header'
-    main
+    main.bg-white
       = render 'application/flash'
       = yield
     = render 'application/footer'

--- a/app/views/posts/_delete_button.html.slim
+++ b/app/views/posts/_delete_button.html.slim
@@ -1,5 +1,6 @@
-= button_to '削除',
-            group_post_path(group, post),
-            method: :delete,
-            data: { turbo_confirm: '本当に削除しますか？' },
-            class: 'text-xs'
+.border-t.text-center.p-1
+  = button_to '削除する',
+              group_post_path(group, post),
+              method: :delete,
+              data: { turbo_confirm: '本当に削除しますか？' },
+              class: 'text-sm text-gray-400 underline hover:text-red-500 hover:no-underline'

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,6 +1,4 @@
 = turbo_frame_tag 'new_post' do
-  = form_with(model: [group, Post.new], class: 'flex space-x-2') do |form|
-    = form.text_field :content, placeholder: '投稿内容を入力', class: 'input input-bordered flex-grow'
-
-    div
-      = form.submit '投稿を作成する', class: 'btn'
+  = form_with(model: [group, Post.new], class: 'flex flex-col') do |form|
+    = form.text_area :content, placeholder: 'コメントを入力', class: 'rounded-md p-2 mb-2'
+    = form.submit 'コメントする', class: 'btn'

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -1,22 +1,12 @@
 = turbo_frame_tag post do
-  .chat.chat-start
-    .chat-image.avatar
-      .w-10.rounded-full
+  .post.border.rounded-md.mb-4
+    .flex.justify-between.items-center.border-b.p-2
+      .flex.items-center
         = link_to("https://github.com/#{post.user.name}", target: '_blank', rel: 'noopener') do
-          = image_tag(post.user.image_url, alt: post.user.name)
-    .chat-header
-      span.text-xs
-        = post.user.name
-        | &nbsp;
-      time.text-xs.opacity-50
-        = l post.created_at, format: :short
-    .flex.items-end.gap-x-2
-      .chat-bubble
-        = post.content
-      = turbo_frame_tag "delete_button_#{post.id}" do
-        - if post.created_by?(current_user)
-          = button_to '削除',
-                      group_post_path(group, post),
-                      method: :delete,
-                      data: { turbo_confirm: '本当に削除しますか？' },
-                      class: 'text-xs'
+          = image_tag(post.user.image_url, class: 'w-6 h-6 rounded-full hover:opacity-50 mr-2', alt: post.user.name)
+        = link_to post.user.name, "https://github.com/#{post.user.name}", target: '_blank', rel: 'noopener', class: 'text-blue-700 underline hover:text-blue-500 hover:no-underline'
+      time.text-sm = l post.created_at, format: :short
+    p.p-2 = post.content
+    = turbo_frame_tag "delete_button_#{post.id}" do
+      - if post.created_by?(current_user)
+        == render partial: 'posts/delete_button', locals: { group:, post: }

--- a/app/views/posts/_posts.html.slim
+++ b/app/views/posts/_posts.html.slim
@@ -1,0 +1,6 @@
+.posts.m-4
+  p.text-xl.font-bold.mb-2
+    | 連絡・コメント&nbsp;
+    i.fa-regular.fa-comments
+  #posts
+    == render partial: 'posts/post', collection: posts, locals: { group: }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -58,4 +58,28 @@ RSpec.describe Group, type: :model do
       end
     end
   end
+
+  describe '#remaining_slots' do
+    let(:group) { create(:group, capacity: 3) }
+
+    context 'when there are no participants' do
+      it 'returns the capacity' do
+        expect(group.remaining_slots).to eq 3
+      end
+    end
+
+    context 'when there are some participants' do
+      it 'returns the number of remaining slots' do
+        create_list(:ticket, 2, group:)
+        expect(group.remaining_slots).to eq 1
+      end
+    end
+
+    context 'when the group is full' do
+      it 'returns 0' do
+        create_list(:ticket, 3, group:)
+        expect(group.remaining_slots).to eq 0
+      end
+    end
+  end
 end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -54,12 +54,15 @@ RSpec.describe 'Groups', type: :system do
 
     it 'displays the group' do
       visit group_path(group)
-      expect(page).to have_link(href: "https://github.com/#{group.owner.name}")
-      expect(page).to have_content group.hashtag
-      expect(page).to have_content group.details
-      expect(page).not_to have_button('すべて見る')
-      expect(page).to have_content group.location
-      expect(page).to have_content group.payment_method
+      within('.group-details') do
+        expect(page).to have_link(href: "https://github.com/#{group.owner.name}")
+        expect(page).to have_content group.hashtag
+        expect(page).to have_content group.details
+        expect(page).to have_content group.location
+        expect(page).to have_content group.payment_method
+      end
+      expect(page).not_to have_css('.participants')
+      expect(page).to have_css('.participation-action-items')
     end
 
     context 'when owner' do

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe 'Groups', type: :system do
 
       it 'display edit and delete links' do
         visit group_path(group)
-        expect(page).to have_link('編集')
-        expect(page).to have_button('削除')
+        expect(page).to have_link('内容修正')
+        expect(page).to have_button('削除する')
       end
     end
 
@@ -86,16 +86,16 @@ RSpec.describe 'Groups', type: :system do
 
       it 'does not display edit and delete links' do
         visit group_path(group)
-        expect(page).not_to have_link('編集')
-        expect(page).not_to have_button('削除')
+        expect(page).not_to have_link('内容修正')
+        expect(page).not_to have_button('削除する')
       end
     end
 
     context 'when guest' do
       it 'does not display edit and delete links' do
         visit group_path(group)
-        expect(page).not_to have_link('編集')
-        expect(page).not_to have_button('削除')
+        expect(page).not_to have_link('内容修正')
+        expect(page).not_to have_button('削除する')
       end
     end
 
@@ -268,7 +268,7 @@ RSpec.describe 'Groups', type: :system do
     before do
       login_as(group.owner)
       visit group_path(group)
-      click_link '編集'
+      click_link '内容修正'
     end
 
     context 'with valid input' do
@@ -323,7 +323,7 @@ RSpec.describe 'Groups', type: :system do
 
       expect do
         accept_confirm do
-          click_button '削除'
+          click_button '削除する'
         end
 
         expect(page).to have_content '2次会グループが削除されました'

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -97,39 +97,39 @@ RSpec.describe 'Groups', type: :system do
     end
 
     context 'when group has participants' do
-      let(:group_with_2_participants) { create(:group) }
       let(:group_with_4_participants) { create(:group) }
+      let(:group_with_6_participants) { create(:group) }
 
       before do
-        create_list(:ticket, 2, group: group_with_2_participants)
         create_list(:ticket, 4, group: group_with_4_participants)
+        create_list(:ticket, 6, group: group_with_6_participants)
       end
 
-      it 'displays all participant icons when there are 3 or fewer participants' do
-        visit group_path(group_with_2_participants)
+      it 'displays all participant icons when there are 5 or fewer participants' do
+        visit group_path(group_with_4_participants)
         within('.participants') do
-          group_with_2_participants.tickets.each do |ticket|
+          group_with_4_participants.tickets.each do |ticket|
             expect(page).to have_css("a[href='https://github.com/#{ticket.user.name}']")
           end
         end
       end
 
-      it 'displays up to 3 participant icons when there are more than 3 participants' do
-        visit group_path(group_with_4_participants)
+      it 'displays up to 5 participant icons when there are more than 5 participants' do
+        visit group_path(group_with_6_participants)
         within('.participants') do
-          group_with_4_participants.tickets.first(3).each do |ticket|
+          group_with_6_participants.tickets.first(5).each do |ticket|
             expect(page).to have_css("a[href='https://github.com/#{ticket.user.name}']")
           end
-          expect(page).not_to have_css("a[href='https://github.com/#{group_with_4_participants.tickets.last.user.name}']")
+          expect(page).not_to have_css("a[href='https://github.com/#{group_with_6_participants.tickets.last.user.name}']")
         end
       end
 
       it 'displays all participant icons and names in the modal' do
-        visit group_path(group_with_4_participants)
+        visit group_path(group_with_6_participants)
         click_button 'すべて見る'
 
         within('dialog#modal.modal') do
-          group_with_4_participants.tickets.each do |ticket|
+          group_with_6_participants.tickets.each do |ticket|
             expect(page).to have_css("a[href='https://github.com/#{ticket.user.name}']")
             expect(page).to have_css("img[src='#{ticket.user.image_url}']")
             expect(page).to have_content(ticket.user.name)

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -57,8 +57,7 @@ RSpec.describe 'Groups', type: :system do
       expect(page).to have_link(href: "https://github.com/#{group.owner.name}")
       expect(page).to have_content group.hashtag
       expect(page).to have_content group.details
-      expect(page).to have_content group.capacity
-      expect(page).not_to have_button('参加者一覧を見る')
+      expect(page).not_to have_button('すべて見る')
       expect(page).to have_content group.location
       expect(page).to have_content group.payment_method
     end
@@ -112,7 +111,6 @@ RSpec.describe 'Groups', type: :system do
           group_with_2_participants.tickets.each do |ticket|
             expect(page).to have_css("a[href='https://github.com/#{ticket.user.name}']")
           end
-          expect(page).not_to have_css('.additional-participants-count')
         end
       end
 
@@ -123,15 +121,14 @@ RSpec.describe 'Groups', type: :system do
             expect(page).to have_css("a[href='https://github.com/#{ticket.user.name}']")
           end
           expect(page).not_to have_css("a[href='https://github.com/#{group_with_4_participants.tickets.last.user.name}']")
-          expect(page).to have_css('.additional-participants-count', text: '+1')
         end
       end
 
       it 'displays all participant icons and names in the modal' do
         visit group_path(group_with_4_participants)
-        click_button '参加者一覧を見る'
+        click_button 'すべて見る'
 
-        within('dialog#participant_list.modal') do
+        within('dialog#modal.modal') do
           group_with_4_participants.tickets.each do |ticket|
             expect(page).to have_css("a[href='https://github.com/#{ticket.user.name}']")
             expect(page).to have_css("img[src='#{ticket.user.image_url}']")

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -7,29 +7,19 @@ RSpec.describe 'Posts', type: :system do
   let(:user) { create(:user) }
 
   describe 'show posts' do
-    context 'when there are no posts' do
-      it 'displays a no posts message' do
-        visit group_path(group)
-        expect(page).to have_content 'まだ投稿はありません。'
-      end
-    end
-
     context 'when there are posts' do
       let!(:posts) { create_list(:post, 2, group:) }
       let(:post) { posts.first }
 
       it 'displays a list of posts' do
         visit group_path(group)
-        within all('.chat-header').first do
-          expect(page).to have_content post.user.name
-          expect(page).to have_content I18n.l(post.created_at, format: :short)
-        end
-        within all('.chat-image').first do
-          expect(page).to have_link(href: "https://github.com/#{post.user.name}")
+        within all('.post').first do
           expect(page).to have_css("img[src='#{post.user.image_url}']")
+          expect(page).to have_link(post.user.name, href: "https://github.com/#{post.user.name}")
+          expect(page).to have_content I18n.l(post.created_at, format: :short)
+          expect(page).to have_content post.content
         end
-        expect(page).to have_content post.content
-        expect(page).to have_css('.chat-start', count: 2)
+        expect(page).to have_css('.post', count: 2)
       end
     end
 
@@ -54,8 +44,8 @@ RSpec.describe 'Posts', type: :system do
       it 'does not display the delete button' do
         create(:post, group:)
         visit group_path(group)
-        within('.chat') do
-          expect(page).not_to have_button '削除'
+        within('.post') do
+          expect(page).not_to have_button '削除する'
         end
       end
     end
@@ -69,8 +59,8 @@ RSpec.describe 'Posts', type: :system do
 
       it 'displays the delete button' do
         visit group_path(group)
-        within('.chat') do
-          expect(page).to have_button '削除'
+        within('.post') do
+          expect(page).to have_button '削除する'
         end
       end
     end
@@ -83,8 +73,8 @@ RSpec.describe 'Posts', type: :system do
 
       it 'does not display the delete button' do
         visit group_path(group)
-        within('.chat') do
-          expect(page).not_to have_button '削除'
+        within('.post') do
+          expect(page).not_to have_button '削除する'
         end
       end
     end
@@ -101,16 +91,14 @@ RSpec.describe 'Posts', type: :system do
 
         click_button 'サインアップ / ログインをして投稿を作成する'
         expect(page).to have_current_path(group_path(group))
-        expect(page).to have_content 'まだ投稿はありません。'
 
         expect do
           fill_in 'post_content', with: 'テストコメント'
           click_button '投稿を作成する'
           expect(page).to have_content '投稿が作成されました'
           expect(page).to have_content 'テストコメント'
-          expect(page).not_to have_content 'まだ投稿はありません。'
-          within('.chat') do
-            expect(page).to have_button '削除'
+          within('.post') do
+            expect(page).to have_button '削除する'
           end
         end.to change(Post, :count).by(1)
 
@@ -156,7 +144,6 @@ RSpec.describe 'Posts', type: :system do
     context 'when creating a post' do
       it 'display the creates post and does not display the post delete button in a different session' do
         visit group_path(group)
-        expect(page).to have_content 'まだ投稿はありません。'
 
         using_session('post creator session') do
           login_as(user)
@@ -167,10 +154,9 @@ RSpec.describe 'Posts', type: :system do
 
         # reverts to different session
         expect(page).to have_content 'テストコメント'
-        expect(page).not_to have_content 'まだ投稿はありません。'
         expect(page).not_to have_content '投稿が作成されました'
-        within('.chat') do
-          expect(page).not_to have_button '削除'
+        within('.post') do
+          expect(page).not_to have_button '削除する'
         end
       end
     end
@@ -184,18 +170,16 @@ RSpec.describe 'Posts', type: :system do
         login_as(post.user)
         visit group_path(group)
         expect(page).to have_content post.content
-        expect(page).not_to have_content 'まだ投稿はありません。'
 
         expect do
           accept_confirm do
-            within('.chat') do
-              click_button '削除'
+            within('.post') do
+              click_button '削除する'
             end
           end
 
           expect(page).to have_content '投稿が削除されました'
           expect(page).not_to have_content post.content
-          expect(page).to have_content 'まだ投稿はありません。'
         end.to change(Post, :count).by(-1)
 
         expect(page).to have_current_path(group_path(group))
@@ -204,21 +188,19 @@ RSpec.describe 'Posts', type: :system do
       it 'does not display the deleted post in a different session' do
         visit group_path(group)
         expect(page).to have_content post.content
-        expect(page).not_to have_content 'まだ投稿はありません。'
 
         using_session('post owner session') do
           login_as(post.user)
           visit group_path(group)
           accept_confirm do
-            within('.chat') do
-              click_button '削除'
+            within('.post') do
+              click_button '削除する'
             end
           end
         end
 
         # reverts to different session
         expect(page).not_to have_content post.content
-        expect(page).to have_content 'まだ投稿はありません。'
         expect(page).not_to have_content '投稿が削除されました'
       end
     end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe 'Posts', type: :system do
       it 'displays the post form' do
         visit group_path(group)
         expect(page).to have_field 'post_content'
-        expect(page).to have_button '投稿を作成する'
+        expect(page).to have_button 'コメントする'
       end
     end
 
     context 'when user is not logged in' do
       it 'displays a log in and create button' do
         visit group_path(group)
-        expect(page).to have_button 'サインアップ / ログインをして投稿を作成する'
+        expect(page).to have_button 'サインアップ / ログインをしてコメントする'
       end
 
       it 'does not display the delete button' do
@@ -89,12 +89,12 @@ RSpec.describe 'Posts', type: :system do
       it 'creates a post' do
         visit group_path(group)
 
-        click_button 'サインアップ / ログインをして投稿を作成する'
+        click_button 'サインアップ / ログインをしてコメントする'
         expect(page).to have_current_path(group_path(group))
 
         expect do
           fill_in 'post_content', with: 'テストコメント'
-          click_button '投稿を作成する'
+          click_button 'コメントする'
           expect(page).to have_content '投稿が作成されました'
           expect(page).to have_content 'テストコメント'
           within('.post') do
@@ -115,7 +115,7 @@ RSpec.describe 'Posts', type: :system do
         visit group_path(group)
 
         expect do
-          click_button '投稿を作成する'
+          click_button 'コメントする'
           expect(page).to have_content '投稿内容を入力してください'
         end.not_to change(Post, :count)
 
@@ -133,7 +133,7 @@ RSpec.describe 'Posts', type: :system do
 
         expect do
           fill_in 'post_content', with: 'a' * 2001
-          click_button '投稿を作成する'
+          click_button 'コメントする'
           expect(page).to have_content '投稿内容は2000文字以内で入力してください'
         end.not_to change(Post, :count)
 
@@ -149,7 +149,7 @@ RSpec.describe 'Posts', type: :system do
           login_as(user)
           visit group_path(group)
           fill_in 'post_content', with: 'テストコメント'
-          click_button '投稿を作成する'
+          click_button 'コメントする'
         end
 
         # reverts to different session

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Tickets', type: :system do
 
         within('.participants') do
           expect(page).to have_link href: "https://github.com/#{user.name}"
-          expect(page).to have_content '1人の参加者'
+          expect(page).to have_content '参加者(1名 / 1名)'
         end
 
         expect do
@@ -91,7 +91,7 @@ RSpec.describe 'Tickets', type: :system do
 
         within('.participants') do
           expect(page).to have_link href: "https://github.com/#{user.name}"
-          expect(page).to have_content '1人の参加者'
+          expect(page).to have_content '参加者(1名 / 10名)'
         end
 
         expect do
@@ -139,7 +139,7 @@ RSpec.describe 'Tickets', type: :system do
           expect(page).to have_content '2次会グループに参加しました'
           within('.participants') do
             expect(page).to have_link href: "https://github.com/#{user.name}"
-            expect(page).to have_content '1人の参加者'
+            expect(page).to have_content '参加者(1名 / 10名)'
           end
           expect(page).to have_button '参加をキャンセルする'
         end.to change(Ticket, :count).by(1)
@@ -229,7 +229,7 @@ RSpec.describe 'Tickets', type: :system do
           expect(page).to have_content '2次会グループに参加しました'
           within('.participants') do
             expect(page).to have_link href: "https://github.com/#{user.name}"
-            expect(page).to have_content '1人の参加者'
+            expect(page).to have_content '参加者(1名 / 10名)'
           end
           expect(page).to have_button '参加をキャンセルする'
         end.to change(Ticket, :count).by(1)

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe 'Tickets', type: :system do
       it 'does not display participation buttons and messages' do
         visit group_path(group)
 
-        expect(page).not_to have_button 'この2次会グループに参加する'
-        expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
-        expect(page).not_to have_button '参加をキャンセルする'
+        expect(page).not_to have_button '2次会に参加する', id: 'participate-button'
+        expect(page).not_to have_button 'サインアップ / ログインをして2次会に参加する', id: 'signup-participate-button'
+        expect(page).not_to have_button '参加を取り消す'
         expect(page).not_to have_content '定員に達したため参加できません'
       end
     end
@@ -58,8 +58,8 @@ RSpec.describe 'Tickets', type: :system do
       it 'displays a cancel button and allows cancellation' do
         visit group_path(group)
 
-        expect(page).not_to have_button 'この2次会グループに参加する'
-        expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
+        expect(page).not_to have_button '2次会に参加する', id: 'participate-button'
+        expect(page).not_to have_button 'サインアップ / ログインをして2次会に参加する', id: 'signup-participate-button'
         expect(page).not_to have_content '定員に達したため参加できません'
 
         within('.participants') do
@@ -68,10 +68,10 @@ RSpec.describe 'Tickets', type: :system do
         end
 
         expect do
-          click_button '参加をキャンセルする'
+          click_button '参加を取り消す'
           expect(page).to have_content 'この2次会グループの参加をキャンセルしました'
           expect(page).not_to have_css('.participants')
-          expect(page).to have_button 'この2次会グループに参加する'
+          expect(page).to have_button '2次会に参加する', id: 'participate-button'
         end.to change(Ticket, :count).by(-1)
 
         expect(page).to have_current_path(group_path(group))
@@ -85,8 +85,8 @@ RSpec.describe 'Tickets', type: :system do
       it 'displays a cancel button and allows cancellation' do
         visit group_path(group)
 
-        expect(page).not_to have_button 'この2次会グループに参加する'
-        expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
+        expect(page).not_to have_button '2次会に参加する', id: 'participate-button'
+        expect(page).not_to have_button 'サインアップ / ログインをして2次会に参加する', id: 'signup-participate-button'
         expect(page).not_to have_content '定員に達したため参加できません'
 
         within('.participants') do
@@ -95,10 +95,10 @@ RSpec.describe 'Tickets', type: :system do
         end
 
         expect do
-          click_button '参加をキャンセルする'
+          click_button '参加を取り消す'
           expect(page).to have_content 'この2次会グループの参加をキャンセルしました'
           expect(page).not_to have_css('.participants')
-          expect(page).to have_button 'この2次会グループに参加する'
+          expect(page).to have_button '2次会に参加する', id: 'participate-button'
         end.to change(Ticket, :count).by(-1)
 
         expect(page).to have_current_path(group_path(group))
@@ -116,9 +116,9 @@ RSpec.describe 'Tickets', type: :system do
 
         expect(page).to have_content '定員に達したため参加できません'
 
-        expect(page).not_to have_button 'この2次会グループに参加する'
-        expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
-        expect(page).not_to have_button '参加をキャンセルする'
+        expect(page).not_to have_button '2次会に参加する', id: 'participate-button'
+        expect(page).not_to have_button 'サインアップ / ログインをして2次会に参加する', id: 'signup-participate-button'
+        expect(page).not_to have_button '参加を取り消す'
       end
     end
 
@@ -128,20 +128,20 @@ RSpec.describe 'Tickets', type: :system do
       it 'displays a participation button and allows participation' do
         visit group_path(group)
 
-        expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
-        expect(page).not_to have_button '参加をキャンセルする'
+        expect(page).not_to have_button 'サインアップ / ログインをして2次会に参加する', id: 'signup-participate-button'
+        expect(page).not_to have_button '参加を取り消す'
         expect(page).not_to have_content '定員に達したため参加できません'
 
         expect(page).not_to have_css('.participants')
 
         expect do
-          click_button 'この2次会グループに参加する'
+          click_button '2次会に参加する', id: 'participate-button'
           expect(page).to have_content '2次会グループに参加しました'
           within('.participants') do
             expect(page).to have_link href: "https://github.com/#{user.name}"
             expect(page).to have_content '参加者(1名 / 10名)'
           end
-          expect(page).to have_button '参加をキャンセルする'
+          expect(page).to have_button '参加を取り消す'
         end.to change(Ticket, :count).by(1)
 
         expect(page).to have_current_path(group_path(group))
@@ -159,9 +159,9 @@ RSpec.describe 'Tickets', type: :system do
 
         expect(page).to have_content '定員に達したため参加できません'
 
-        expect(page).not_to have_button 'この2次会グループに参加する'
-        expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
-        expect(page).not_to have_button '参加をキャンセルする'
+        expect(page).not_to have_button '2次会に参加する', id: 'participate-button'
+        expect(page).not_to have_button 'サインアップ / ログインをして2次会に参加する', id: 'signup-participate-button'
+        expect(page).not_to have_button '参加を取り消す'
       end
     end
 
@@ -171,14 +171,14 @@ RSpec.describe 'Tickets', type: :system do
       it 'displays a log in and participation button but prevents participation for the owner' do
         visit group_path(group)
 
-        expect(page).not_to have_button 'この2次会グループに参加する'
-        expect(page).not_to have_button '参加をキャンセルする'
+        expect(page).not_to have_button '2次会に参加する', id: 'participate-button'
+        expect(page).not_to have_button '参加を取り消す'
         expect(page).not_to have_content '定員に達したため参加できません'
 
         expect(page).not_to have_css('.avatar')
 
         expect do
-          click_button 'サインアップ / ログインをして2次会グループに参加'
+          click_button 'サインアップ / ログインをして2次会に参加する', id: 'signup-participate-button'
           expect(page).to have_content '自身が主催したグループには参加できません'
         end.not_to change(Ticket, :count)
 
@@ -194,14 +194,14 @@ RSpec.describe 'Tickets', type: :system do
       it 'displays a log in and participation button but prevents participation for members' do
         visit group_path(group)
 
-        expect(page).not_to have_button 'この2次会グループに参加する'
-        expect(page).not_to have_button '参加をキャンセルする'
+        expect(page).not_to have_button '2次会に参加する', id: 'participate-button'
+        expect(page).not_to have_button '参加を取り消す'
         expect(page).not_to have_content '定員に達したため参加できません'
 
         expect(page).not_to have_css('.avatar')
 
         expect do
-          click_button 'サインアップ / ログインをして2次会グループに参加'
+          click_button 'サインアップ / ログインをして2次会に参加する', id: 'signup-participate-button'
           expect(page).to have_content 'この2次会グループには既に参加しています'
         end.not_to change(Ticket, :count)
 
@@ -216,8 +216,8 @@ RSpec.describe 'Tickets', type: :system do
       it 'displays a log in and participation button and allows participation' do
         visit group_path(group)
 
-        expect(page).not_to have_button 'この2次会グループに参加する'
-        expect(page).not_to have_button '参加をキャンセルする'
+        expect(page).not_to have_button '2次会に参加する', id: 'participate-button'
+        expect(page).not_to have_button '参加を取り消す'
         expect(page).not_to have_content '定員に達したため参加できません'
 
         expect(page).not_to have_css('.avatar')
@@ -225,13 +225,13 @@ RSpec.describe 'Tickets', type: :system do
         expect(page).not_to have_css('.participants')
 
         expect do
-          click_button 'サインアップ / ログインをして2次会グループに参加'
+          click_button 'サインアップ / ログインをして2次会に参加する', id: 'signup-participate-button'
           expect(page).to have_content '2次会グループに参加しました'
           within('.participants') do
             expect(page).to have_link href: "https://github.com/#{user.name}"
             expect(page).to have_content '参加者(1名 / 10名)'
           end
-          expect(page).to have_button '参加をキャンセルする'
+          expect(page).to have_button '参加を取り消す'
         end.to change(Ticket, :count).by(1)
 
         expect(page).to have_css(".avatar img[src='#{user.image_url}']")

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -62,14 +62,15 @@ RSpec.describe 'Tickets', type: :system do
         expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
         expect(page).not_to have_content '定員に達したため参加できません'
 
-        expect(page).to have_link href: "https://github.com/#{user.name}"
-        expect(page).to have_content "1 / #{group.capacity}人"
+        within('.participants') do
+          expect(page).to have_link href: "https://github.com/#{user.name}"
+          expect(page).to have_content '1人の参加者'
+        end
 
         expect do
           click_button '参加をキャンセルする'
           expect(page).to have_content 'この2次会グループの参加をキャンセルしました'
-          expect(page).not_to have_link href: "https://github.com/#{user.name}"
-          expect(page).to have_content "0 / #{group.capacity}人"
+          expect(page).not_to have_css('.participants')
           expect(page).to have_button 'この2次会グループに参加する'
         end.to change(Ticket, :count).by(-1)
 
@@ -88,14 +89,15 @@ RSpec.describe 'Tickets', type: :system do
         expect(page).not_to have_button 'サインアップ / ログインをして2次会グループに参加'
         expect(page).not_to have_content '定員に達したため参加できません'
 
-        expect(page).to have_link href: "https://github.com/#{user.name}"
-        expect(page).to have_content "1 / #{group.capacity}人"
+        within('.participants') do
+          expect(page).to have_link href: "https://github.com/#{user.name}"
+          expect(page).to have_content '1人の参加者'
+        end
 
         expect do
           click_button '参加をキャンセルする'
           expect(page).to have_content 'この2次会グループの参加をキャンセルしました'
-          expect(page).not_to have_link href: "https://github.com/#{user.name}"
-          expect(page).to have_content "0 / #{group.capacity}人"
+          expect(page).not_to have_css('.participants')
           expect(page).to have_button 'この2次会グループに参加する'
         end.to change(Ticket, :count).by(-1)
 
@@ -130,14 +132,15 @@ RSpec.describe 'Tickets', type: :system do
         expect(page).not_to have_button '参加をキャンセルする'
         expect(page).not_to have_content '定員に達したため参加できません'
 
-        expect(page).not_to have_link href: "https://github.com/#{user.name}"
-        expect(page).to have_content "0 / #{group.capacity}人"
+        expect(page).not_to have_css('.participants')
 
         expect do
           click_button 'この2次会グループに参加する'
           expect(page).to have_content '2次会グループに参加しました'
-          expect(page).to have_link href: "https://github.com/#{user.name}"
-          expect(page).to have_content "1 / #{group.capacity}人"
+          within('.participants') do
+            expect(page).to have_link href: "https://github.com/#{user.name}"
+            expect(page).to have_content '1人の参加者'
+          end
           expect(page).to have_button '参加をキャンセルする'
         end.to change(Ticket, :count).by(1)
 
@@ -219,14 +222,15 @@ RSpec.describe 'Tickets', type: :system do
 
         expect(page).not_to have_css('.avatar')
 
-        expect(page).not_to have_link href: "https://github.com/#{user.name}"
-        expect(page).to have_content "0 / #{group.capacity}人"
+        expect(page).not_to have_css('.participants')
 
         expect do
           click_button 'サインアップ / ログインをして2次会グループに参加'
           expect(page).to have_content '2次会グループに参加しました'
-          expect(page).to have_link href: "https://github.com/#{user.name}"
-          expect(page).to have_content "1 / #{group.capacity}人"
+          within('.participants') do
+            expect(page).to have_link href: "https://github.com/#{user.name}"
+            expect(page).to have_content '1人の参加者'
+          end
           expect(page).to have_button '参加をキャンセルする'
         end.to change(Ticket, :count).by(1)
 


### PR DESCRIPTION
## Issue
- #129 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [x] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- グループ詳細ページ(`/groups/{ID}`)のレイアウトを修正した
  - グループ詳細
  - 参加ボタン
  - 参加者表示
  - シェアボタン
  - コメント表示
  - コメント作成フォーム
- htmlタグとmainタグの背景色を追加
- ヘッダーとフッターを微調整
- [Font Awesome](https://fontawesome.com/)を導入した

## 動作確認方法
1. `chore/#129/fix-group-show-page-design`をローカルに取り込む
1. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
1. グループ詳細ページ(`/groups/{ID}`)のレイアウトが変更されていることを確認する

## スクリーンショット
### 変更前
定員に達している時
![before_full](https://github.com/user-attachments/assets/249fed8c-e221-4ef2-b1a9-74e6f8e02867)

参加ボタン
![before_participation](https://github.com/user-attachments/assets/4cc4ae57-6628-4254-9ca8-de79111af43f)

キャンセルボタン
![before_cancel](https://github.com/user-attachments/assets/86977aa5-9a8e-40e1-87d8-1b404127d9c9)

コメント
![before_comment](https://github.com/user-attachments/assets/233a4f8c-aa60-44b9-873b-6357e921b6d3)

### 変更後
定員に達している時
![after_full](https://github.com/user-attachments/assets/598817e8-2eb5-4e34-842e-53162cfaf37d)

参加ボタン
![after_participation](https://github.com/user-attachments/assets/de4e03b8-1015-4605-bbd7-adc02c353f8a)

キャンセルボタン
![after_cancel](https://github.com/user-attachments/assets/d8f1605f-8f8a-46b8-b320-5b70d3289882)

コメント
![after_comment](https://github.com/user-attachments/assets/904f9d93-bdc4-458c-8868-eba908832de1)