### PR TITLE
グループをハッシュタグごとにまとめて一覧表示するように変更した

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,7 +5,7 @@ class GroupsController < ApplicationController
   skip_before_action :authenticate, only: %i[index show]
 
   def index
-    @groups = Group.order(:created_at)
+    @groups_grouped_by_hashtag = Group.order(:hashtag, :created_at).group_by(&:hashtag)
   end
 
   def show

--- a/app/views/groups/_groups.html.slim
+++ b/app/views/groups/_groups.html.slim
@@ -1,0 +1,27 @@
+.groups_by_hashtag.m-4
+  - groups_grouped_by_hashtag.each do |hashtag, groups|
+    p.text-xl.font-bold.mb-2
+      = link_to "##{hashtag}", "https://x.com/search?q=%23#{hashtag}", target: '_blank', rel: 'noopener', class: 'text-blue-700 underline hover:text-blue-500 hover:no-underline'
+      | &nbsp;の2次会一覧
+
+    .groups.border.rounded-md.mb-2
+      - groups.each do |group|
+        .group.flex.items-start.border-b.last:border-none.p-2
+          = link_to("https://github.com/#{group.owner.name}", target: '_blank', rel: 'noopener') do
+            = image_tag(group.owner.image_url, class: 'min-w-10 h-10 rounded-full hover:opacity-50 mr-2')
+          div
+            = link_to group.details, group_path(group), class: 'font-bold text-blue-700 underline hover:text-blue-500 hover:no-underline'
+            .flex.text-sm.text-gray-500.pt-1
+              .flex.items-center.mr-4
+                i.fa-solid.fa-location-dot.mr-1
+                p = group.location
+              .flex.items-center
+                i.fa-solid.fa-sack-dollar.mr-1
+                p = group.payment_method
+            .flex.text-sm.text-gray-500.pt-1
+              p = "#{group.tickets.count}名 / #{group.capacity}名"
+              - if group.posts.any?
+                p.ml-4 = "コメント(#{group.posts.count})"
+
+  .hidden.only:block
+    | まだ2次会グループはありません。

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -14,22 +14,4 @@ p.mb-4
     span.text-xs
       | GitHubアカウントが必要です
 
-#groups
-  p.text-xl.font-bold.mb-4
-    | 2次会グループ一覧
-
-  - if @groups.any?
-    - @groups.each do |group|
-      = link_to group_path(group), class: 'flex justify-between items-start mb-4 p-4 shadow-md' do
-        .flex.flex-col.items-center
-          p.text-sm.font-bold 主催者
-          = image_tag(group.owner.image_url, class: 'w-12 h-12 rounded-full')
-        .flex-1.ml-4
-          p.font-bold = "#{group.hashtag} の2次会"
-          p.text-lg.font-semibold = group.details
-          .flex.justify-between.items-center.mt-2
-            p.text-sm.text-gray-600 会場: #{group.location}
-            p.text-sm.text-gray-600 = "#{group.tickets.count} / #{group.capacity}人"
-  - else
-    p
-      | まだ2次会グループはありません。
+== render partial: 'groups/groups', locals: { groups_grouped_by_hashtag: @groups_grouped_by_hashtag }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,8 +8,8 @@ users = users_data.map { |user_data| User.create!(user_data) }
 
 groups_data = [
   { hashtag: 'rubykaigi', details: '誰でも参加OK!!', capacity: 2, location: '未定', payment_method: '割り勘', owner_id: users[0].id },
-  { hashtag: 'kaigionrails', details: 'サシで話したい', capacity: 1, location: '未定', payment_method: '奢ります', owner_id: users[1].id },
-  { hashtag: 'rubyworld', details: 'Anyone who loves Ruby is welcome to join', capacity: 10, location: 'Somewhere in Japan',
+  { hashtag: 'rubykaigi', details: 'サシで話したい', capacity: 1, location: '未定', payment_method: '奢ります', owner_id: users[1].id },
+  { hashtag: 'rubykaigi', details: 'Anyone who loves Ruby is welcome to join', capacity: 10, location: 'Somewhere in Japan',
     payment_method: 'split bill', owner_id: users[2].id },
   { hashtag: 'bigparty', details: 'みんなで楽しく飲みましょう！', capacity: 100, location: '未定', payment_method: '割り勘', owner_id: users[0].id }
 ]

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -15,16 +15,26 @@ RSpec.describe 'Groups', type: :system do
       let!(:groups) { create_list(:group, 2) }
       let(:group) { groups.first }
 
+      before do
+        create(:post, group:)
+      end
+
       it 'displays a list of groups' do
         visit groups_path
-        expect(page).to have_content '2次会グループ一覧'
-        expect(page).to have_css("img[src='#{group.owner.image_url}']")
-        expect(page).to have_content group.hashtag
-        expect(page).to have_content group.details
-        expect(page).to have_content group.capacity
-        expect(page).to have_content group.location
-        expect(page).not_to have_content group.payment_method
-        expect(page).to have_css('#groups a', count: groups.count)
+        expect(page).to have_content "##{group.hashtag} の2次会一覧"
+        within all('.group').first do
+          expect(page).to have_css("img[src='#{group.owner.image_url}']")
+          expect(page).to have_link href: "https://github.com/#{group.owner.name}"
+          expect(page).to have_link(group.details, href: group_path(group))
+          expect(page).to have_content group.location
+          expect(page).to have_content group.payment_method
+          expect(page).to have_content "#{group.tickets.count}名 / #{group.capacity}名"
+          expect(page).to have_content "コメント(#{group.posts.count})"
+        end
+        within all('.group').last do
+          expect(page).not_to have_content 'コメント'
+        end
+        expect(page).to have_css('.group', count: groups.count)
       end
     end
 


### PR DESCRIPTION
## Issue
- #116 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [x] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- 2次会グループをハッシュタグごとにまとめて表示するようにした
- seedデータを修正した

## 動作確認方法
1. `feat/#116/sort-groups-by-hashtag-and-date`をローカルに取り込む
1. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
1. 2次会グループがハッシュタグごとにまとめて表示されていることを確認する

## スクリーンショット
### 変更前
<img width="668" alt="before_index" src="https://github.com/user-attachments/assets/38adcd4b-7f70-472d-9f53-32bbf58ce72d" />

### 変更後
<img width="668" alt="after_index" src="https://github.com/user-attachments/assets/30187a71-46fe-49d3-9796-c3169af5857c" />
