### PR TITLE
ハッシュタグ入力欄に入力できる文字をTwitterのハッシュタグで利用できる文字のみに制限した

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -17,7 +17,7 @@ class GroupsController < ApplicationController
 
   def new
     @group = current_user.groups.new(
-      details: '誰でも参加OK!!',
+      details: '誰でも参加OK！',
       capacity: 10,
       location: '未定',
       payment_method: '割り勘'

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,13 +5,14 @@ class Group < ApplicationRecord
   has_many :tickets, dependent: :destroy
   has_many :posts, dependent: :destroy
 
-  validates :hashtag, presence: true, length: { maximum: 50 }
+  validates :hashtag, presence: true, length: { maximum: 50 }, format: { with: /\A[\p{Alnum}_]+\z/, message: 'にはスペースや記号は使用できません。' }
   validates :details, presence: true, length: { maximum: 2000 }
   validates :capacity, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :location, presence: true, length: { maximum: 100 }
   validates :payment_method, presence: true, length: { maximum: 50 }
 
   validate :capacity_cannot_be_less_than_participants, on: :update
+  validate :hashtag_cannot_be_numbers_or_underscores_only
 
   def created_by?(user)
     return false unless user
@@ -33,5 +34,12 @@ class Group < ApplicationRecord
     return unless capacity < tickets.count
 
     errors.add(:capacity, 'は参加人数以上の値にしてください')
+  end
+
+  def hashtag_cannot_be_numbers_or_underscores_only
+    return if hashtag.blank?
+    return unless hashtag.match?(/\A[0-9_]+\z/)
+
+    errors.add(:hashtag, 'は数字、アンダースコアのみでは登録できません')
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,13 +5,14 @@ class Group < ApplicationRecord
   has_many :tickets, dependent: :destroy
   has_many :posts, dependent: :destroy
 
-  validates :hashtag, presence: true, length: { maximum: 50 }, format: { with: /\A[\p{Alnum}_]+\z/, message: 'にはスペースや記号は使用できません。' }
+  validates :hashtag, presence: true, length: { maximum: 50 }
   validates :details, presence: true, length: { maximum: 2000 }
   validates :capacity, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :location, presence: true, length: { maximum: 100 }
   validates :payment_method, presence: true, length: { maximum: 50 }
 
   validate :capacity_cannot_be_less_than_participants, on: :update
+  validate :hashtag_format
   validate :hashtag_cannot_be_numbers_or_underscores_only
 
   def created_by?(user)
@@ -34,6 +35,13 @@ class Group < ApplicationRecord
     return unless capacity < tickets.count
 
     errors.add(:capacity, 'は参加人数以上の値にしてください')
+  end
+
+  def hashtag_format
+    return if hashtag.blank?
+    return if hashtag.match?(/\A[\p{Alnum}_]+\z/)
+
+    errors.add(:hashtag, 'にはスペースや記号は使用できません。')
   end
 
   def hashtag_cannot_be_numbers_or_underscores_only

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Group < ApplicationRecord
+  before_save :remove_leading_hash_from_hashtag
+
   belongs_to :owner, class_name: 'User', inverse_of: :groups
   has_many :tickets, dependent: :destroy
   has_many :posts, dependent: :destroy
@@ -39,7 +41,7 @@ class Group < ApplicationRecord
 
   def hashtag_format
     return if hashtag.blank?
-    return if hashtag.match?(/\A[\p{Alnum}_]+\z/)
+    return if hashtag.match?(/\A#?[\p{Alnum}_]+\z/)
 
     errors.add(:hashtag, 'にはスペースや記号は使用できません。')
   end
@@ -49,5 +51,9 @@ class Group < ApplicationRecord
     return unless hashtag.match?(/\A[0-9_]+\z/)
 
     errors.add(:hashtag, 'は数字、アンダースコアのみでは登録できません')
+  end
+
+  def remove_leading_hash_from_hashtag
+    self.hashtag = hashtag.delete_prefix('#')
   end
 end

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -6,33 +6,40 @@
         - group.errors.each do |error|
           li = error.full_message
 
-  .mb-4
-    = form.label :hashtag, style: 'display: block'
-    = form.text_field :hashtag
-    p.text-gray-400.text-sm
-      | 現在参加しているイベントのハッシュタグを入力してください。
+  .form__items
+    .form-item.mb-6
+      = form.label :hashtag, class: 'block text-sm font-bold mb-2'
+      = form.text_field :hashtag, class: 'block w-full rounded-md mb-1', placeholder: 'rubykaigi'
+      p.text-gray-400.text-sm
+        | 現在参加しているイベントのハッシュタグを入力してください。
+    .form-item.mb-6
+      = form.label :details, class: 'block text-sm font-bold mb-2'
+      = form.text_area :details, class: 'block w-full rounded-md p-2  mb-1', rows: 3, placeholder: '誰でも参加OK！'
+      p.text-gray-400.text-sm
+        | どんな人に参加して欲しいですか？どんな2次会を開催予定ですか？<br>例）イベント参加者限定、〇〇について語りたい！
+    .form-item.mb-6
+      = form.label :capacity, class: 'block text-sm font-bold mb-2'
+      = form.number_field :capacity, class: 'block w-full rounded-md mb-1', placeholder: '10'
+    .form-item.mb-6
+      = form.label :location, class: 'block text-sm font-bold mb-2'
+      = form.text_field :location, class: 'block w-full rounded-md mb-1', placeholder: '未定'
+      p.text-gray-400.text-sm
+        | 例）〇〇駅周辺の居酒屋
+    .form-item.mb-6
+      = form.label :payment_method, class: 'block text-sm font-bold mb-2'
+      = form.text_field :payment_method, class: 'block w-full rounded-md mb-1', placeholder: '割り勘'
+      p.text-gray-400.text-sm
+        | トラブル防止のため、事前に会計方法を決めておきましょう。<br>例）乾杯前に3000円集金します、個別会計
 
-  .mb-4
-    = form.label :details, style: 'display: block'
-    = form.text_area :details
-    p.text-gray-400.text-sm
-      | どんな人に参加して欲しいですか？どんな2次会を開催予定ですか？<br>例）女性限定、イベントの参加者で交流したい！
-
-  .mb-4
-    = form.label :capacity, style: 'display: block'
-    = form.number_field :capacity
-
-  .mb-4
-    = form.label :location, style: 'display: block'
-    = form.text_field :location
-    p.text-gray-400.text-sm
-      | 例）〇〇駅周辺の居酒屋
-
-  .mb-4
-    = form.label :payment_method, style: 'display: block'
-    = form.text_field :payment_method
-    p.text-gray-400.text-sm
-      | トラブル防止のため、事前に会計方法を決めておきましょう。<br>例）乾杯前に3000円集金します、個別会計
-
-  div
-    = form.submit
+  .form-actions
+    ul.form-actions__items
+      li.form-actions__item.is-main.mb-2
+        - if group.new_record?
+          = form.submit '2次会グループを作成', class: 'btn bg-blue-500 hover:bg-blue-700 text-white w-full'
+        - else
+          = form.submit '内容を更新', class: 'btn bg-blue-500 hover:bg-blue-700 text-white w-full'
+      li.form-actions__item.is-sub.text-center
+        - if group.new_record?
+          = link_to 'キャンセル', groups_path, class: 'text-sm text-gray-400 underline hover:no-underline'
+        - else
+          = link_to 'キャンセル', group_path(group), class: 'text-sm text-gray-400 underline hover:no-underline'

--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -1,7 +1,5 @@
-h1.text-2xl.font-bold.mb-4
-  | 2次会グループを編集
+.m-4
+  h2.text-xl.font-bold.mb-4
+    | 2次会グループ編集
 
-== render 'form', group: @group
-
-div
-  = link_to 'キャンセル', @group
+  == render 'form', group: @group

--- a/app/views/groups/new.html.slim
+++ b/app/views/groups/new.html.slim
@@ -1,10 +1,5 @@
-h1.text-2xl.font-bold.mb-4
-  | 2次会グループを作成
+.m-4
+  h2.text-xl.font-bold.mb-4
+    | 2次会グループ作成
 
-p.mb-4
-  | 2次会グループを作成して、イベントのハッシュタグをつけてXに投稿して参加者を募集しましょう。<br>作成した2次会グループページ上で参加者と連絡を取ることができます。
-
-== render 'form', group: @group
-
-div
-  = link_to 'キャンセル', groups_path
+  == render 'form', group: @group

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ end
 users = users_data.map { |user_data| User.create!(user_data) }
 
 groups_data = [
-  { hashtag: 'rubykaigi', details: '誰でも参加OK!!', capacity: 2, location: '未定', payment_method: '割り勘', owner_id: users[0].id },
+  { hashtag: 'rubykaigi', details: '誰でも参加OK！', capacity: 2, location: '未定', payment_method: '割り勘', owner_id: users[0].id },
   { hashtag: 'rubykaigi', details: 'サシで話したい', capacity: 1, location: '未定', payment_method: '奢ります', owner_id: users[1].id },
   { hashtag: 'rubykaigi', details: 'Anyone who loves Ruby is welcome to join', capacity: 10, location: 'Somewhere in Japan',
     payment_method: 'split bill', owner_id: users[2].id },

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :group do
     hashtag { 'rubykaigi' }
-    details { '誰でも参加OK!!' }
+    details { '誰でも参加OK！' }
     capacity { 10 }
     location { '未定' }
     payment_method { '割り勘' }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -17,6 +17,74 @@ RSpec.describe Group, type: :model do
     it { is_expected.to validate_length_of(:payment_method).is_at_most(50) }
   end
 
+  describe '#hashtag_format' do
+    let(:group) { build(:group) }
+
+    it 'is valid with a valid hashtag' do
+      group.hashtag = 'validHashtag'
+      expect(group).to be_valid
+    end
+
+    it 'is valid with a hashtag starting with #' do
+      group.hashtag = '#validHashtag'
+      expect(group).to be_valid
+    end
+
+    it 'is invalid with a hashtag starting with multiple #' do
+      group.hashtag = '##invalidHashtag'
+      expect(group).to be_invalid
+    end
+
+    it 'is invalid with a hashtag containing spaces' do
+      group.hashtag = 'invalid hashtag'
+      expect(group).to be_invalid
+      expect(group.errors[:hashtag]).to include('にはスペースや記号は使用できません。')
+    end
+
+    it 'is invalid with a hashtag containing special characters' do
+      group.hashtag = 'invalid@hashtag'
+      expect(group).to be_invalid
+      expect(group.errors[:hashtag]).to include('にはスペースや記号は使用できません。')
+    end
+  end
+
+  describe '#hashtag_cannot_be_numbers_or_underscores_only' do
+    let(:group) { build(:group) }
+
+    it 'is invalid with a hashtag containing only numbers' do
+      group.hashtag = '123'
+      expect(group).to be_invalid
+      expect(group.errors[:hashtag]).to include('は数字、アンダースコアのみでは登録できません')
+    end
+
+    it 'is invalid with a hashtag containing only underscores' do
+      group.hashtag = '_'
+      expect(group).to be_invalid
+      expect(group.errors[:hashtag]).to include('は数字、アンダースコアのみでは登録できません')
+    end
+
+    it 'is invalid with a hashtag containing only numbers and underscores' do
+      group.hashtag = '123_'
+      expect(group).to be_invalid
+      expect(group.errors[:hashtag]).to include('は数字、アンダースコアのみでは登録できません')
+    end
+
+    it 'is valid with a hashtag containing letters and numbers' do
+      group.hashtag = 'valid123'
+      expect(group).to be_valid
+    end
+  end
+
+  describe '#remove_leading_hash_from_hashtag' do
+    let(:group) { build(:group) }
+
+    it 'removes leading # from hashtag before save' do
+      group.hashtag = '#validHashtag'
+      group.save
+      expect(group.hashtag).to eq('validHashtag')
+    end
+  end
+
   describe '#created_by?' do
     let(:owner) { create(:user) }
     let(:other_user) { create(:user) }

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -164,13 +164,14 @@ RSpec.describe 'Groups', type: :system do
         visit groups_path
         click_link '2次会グループを作成'
         expect(page).to have_current_path(new_group_path)
-        expect(page).to have_content '2次会グループを作成'
+        expect(page).to have_content '2次会グループ作成'
         expect(page).to have_field 'イベントのハッシュタグ'
-        expect(page).to have_field '募集内容', with: '誰でも参加OK!!'
+        expect(page).to have_field '募集内容', with: '誰でも参加OK！'
         expect(page).to have_field '定員', with: 10
         expect(page).to have_field '会場', with: '未定'
         expect(page).to have_field '会計方法', with: '割り勘'
-        expect(page).to have_button '登録する'
+        expect(page).to have_button '2次会グループを作成'
+        expect(page).to have_link('キャンセル', href: groups_path)
       end
     end
 
@@ -197,11 +198,11 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_current_path(new_group_path)
         expect do
           fill_in 'イベントのハッシュタグ', with: 'rubykaigi'
-          fill_in '募集内容', with: '誰でも参加OK!!'
+          fill_in '募集内容', with: '誰でも参加OK！'
           fill_in '定員', with: 10
           fill_in '会場', with: '未定'
           fill_in '会計方法', with: '割り勘'
-          click_button '登録する'
+          click_button '2次会グループを作成'
 
           expect(page).to have_content '2次会グループが作成されました'
         end.to change(Group, :count).by(1)
@@ -215,11 +216,11 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_current_path(new_group_path)
         expect do
           fill_in 'イベントのハッシュタグ', with: ''
-          fill_in '募集内容', with: '誰でも参加OK!!'
+          fill_in '募集内容', with: '誰でも参加OK！'
           fill_in '定員', with: 10
           fill_in '会場', with: '未定'
           fill_in '会計方法', with: '割り勘'
-          click_button '登録する'
+          click_button '2次会グループを作成'
 
           expect(page).to have_content '2次会グループに1個のエラーが発生しました'
           expect(page).to have_content 'イベントのハッシュタグを入力してください'
@@ -240,13 +241,13 @@ RSpec.describe 'Groups', type: :system do
 
       it 'displays a form to edit the group' do
         visit edit_group_path(group)
-        expect(page).to have_content '2次会グループを編集'
+        expect(page).to have_content '2次会グループ編集'
         expect(page).to have_field 'イベントのハッシュタグ', with: group.hashtag
         expect(page).to have_field '募集内容', with: group.details
         expect(page).to have_field '定員', with: group.capacity
         expect(page).to have_field '会場', with: group.location
         expect(page).to have_field '会計方法', with: group.payment_method
-        expect(page).to have_button '更新する'
+        expect(page).to have_button '内容を更新'
       end
     end
 
@@ -286,7 +287,7 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_current_path(edit_group_path(group))
 
         fill_in '会場', with: 'とある居酒屋'
-        click_button '更新する'
+        click_button '内容を更新'
 
         expect(page).to have_content '2次会グループが更新されました'
         expect(page).to have_content 'とある居酒屋'
@@ -299,7 +300,7 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_current_path(edit_group_path(group))
 
         fill_in '会場', with: ''
-        click_button '更新する'
+        click_button '内容を更新'
 
         expect(page).to have_content '2次会グループに1個のエラーが発生しました'
         expect(page).to have_content '会場を入力してください'
@@ -312,7 +313,7 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_current_path(edit_group_path(group))
 
         fill_in '定員', with: '1'
-        click_button '更新する'
+        click_button '内容を更新'
 
         expect(page).to have_content '2次会グループに1個のエラーが発生しました'
         expect(page).to have_content '定員は参加人数以上の値にしてください'


### PR DESCRIPTION
## Issue
- #99 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- ハッシュタグ入力欄に入力できる文字を、Twitterのハッシュタグで利用できる文字のみに制限した。
  - 以下は使用できない。
    - スペース、記号、絵文字
    - 数字のみ、アンダースコアのみ、数字とアンダースコアのみ
  - Twitterのハッシュタグで利用できる文字に関する公式ドキュメントが見つからなかったため、https://github.com/djkazunoko/nijikai-go/issues/99#issuecomment-2745031631 の参考資料を元に実際にTwitter上で確認を行い、仕様を決めた。
- ハッシュタグ入力欄の先頭に`#`が1つだけある場合は`#`を取り除いてsaveするようにした。
  - ハッシュタグ入力欄で先頭の`#`をつける必要はないが、ユーザが間違えて先頭の`#`をつけた場合に内部的に取り除くようにした。わざわざエラーを出して再入力させるのはユーザにとって手間だと判断した。
- グループ作成/編集画面のデザインを修正した。

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [Active Record バリデーション - 2.5 format - Railsガイド](https://railsguides.jp/active_record_validations.html#format)
- [正規表現 (Ruby 3.4 リファレンスマニュアル) - Unicode プロパティによる文字クラス指定](https://docs.ruby-lang.org/ja/latest/doc/spec=2fregexp.html)
  - [Onigumo/doc/UnicodeProps.txt](https://github.com/k-takata/Onigmo/blob/master/doc/UnicodeProps.txt)
- [[連載:正規表現] Unicode文字プロパティについて(2) -- Pの一族｜TechRacho by BPS株式会社](https://techracho.bpsinc.jp/hachi8833/2013_09_27/13713)
- [はじめての正規表現とベストプラクティス#7: Unicode文字ポイントとUnicode文字クラスのプロパティ｜TechRacho by BPS株式会社](https://techracho.bpsinc.jp/hachi8833/2019_02_20/69831)
  - [Unicode Character Categories](https://www.compart.com/en/unicode/category)
- [Regex Tutorial - POSIX Bracket Expressions](https://www.regular-expressions.info/posixbrackets.html)
- [Chapter 4 – 4.5 General Category - Unicode 16.0.0](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-4/#G124142)

## 動作確認方法
1. `feat/#99/validate-hashtag-input`をローカルに取り込む
2. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
3. グループ作成/編集フォームの「イベントのハッシュタグ」入力欄で以下が使用出来ないことを確認する
  - スペース、記号、絵文字
  - 数字のみ、アンダースコアのみ、数字とアンダースコアのみ
4. グループ作成/編集フォームの「イベントのハッシュタグ」入力欄で`#hashtag`を入力して保存すると、保存される値が`hashtag`になることを確認する

## スクリーンショット
### 変更前
`/groups/new`
![before_create](https://github.com/user-attachments/assets/67855a39-1492-4fd9-8499-b5a3b2b2c846)

`/groups/{ID}/edit`
![before_edit](https://github.com/user-attachments/assets/331f28da-3ecb-439a-9703-8674a9adf199)

### 変更後
`/groups/new`
![after_create](https://github.com/user-attachments/assets/c6f899be-9083-4e7a-9579-725bee1ced3d)

`/groups/{ID}/edit`
![after_edit](https://github.com/user-attachments/assets/bdf551a6-035f-42b4-a047-7b999add5ce1)