### PR TITLE
Revert グループの定時削除機能を実装した 

### DIFF
--- a/.github/workflows/schedule_destroy_groups.yml
+++ b/.github/workflows/schedule_destroy_groups.yml
@@ -1,0 +1,15 @@
+name: Schedule Destroy Groups
+
+on:
+  schedule:
+    - cron: '0 20 * * *'
+
+jobs:
+  destroy-groups:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: fly ssh console -C "/rails/bin/rails groups:destroy_all"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/lib/tasks/destroy_all_groups.rake
+++ b/lib/tasks/destroy_all_groups.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :groups do
+  desc 'Destroy all groups and their associated tickets and posts'
+  task destroy_all: :environment do
+    Group.destroy_all
+  end
+end


### PR DESCRIPTION
## Issue
- #102 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [ ] test: テスト関連
- [x] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- 全ての2次会グループを削除するrakeタスクを作成した。
- 上記のrakeタスクを1日1回日本時間AM5:00に実行するGitHub Actionsワークフローを作成した。

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [Railsガイド: コマンドラインツール - 2.15 カスタムRakeタスク](https://railsguides.jp/command_line.html#%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%A0rake%E3%82%BF%E3%82%B9%E3%82%AF)
- [ActiveRecord::Relation#destroy_all](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-destroy_all)
- [fly ssh console · Fly Docs](https://fly.io/docs/flyctl/ssh-console/)
- [superfly/flyctl-actions](https://github.com/superfly/flyctl-actions)
- [GitHub Action for flyctl · Actions · GitHub Marketplace](https://github.com/marketplace/actions/github-action-for-flyctl)
- [Continuous Deployment with Fly.io and GitHub Actions · Fly Docs](https://fly.io/docs/launch/continuous-deployment-with-github-actions/)
- [Running Tasks & Consoles · Fly Docs](https://fly.io/docs/rails/the-basics/run-tasks-and-consoles/)

## 動作確認方法
1. https://nijikai-go.fly.dev/ にアクセスして、任意のグループを作成する
1. 翌日AM5:00に作成したグループが削除されていることを確認する
