### PR TITLE
textareaの改行を表示に反映した

### DIFF
--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -1,5 +1,5 @@
 .details.py-2
-  p.font-bold = group.details
+  p.font-bold = safe_join(group.details.split("\n"), tag.br)
 
 .location.flex.items-center.py-2
   i.fa-solid.fa-location-dot.mr-2

--- a/app/views/groups/_groups.html.slim
+++ b/app/views/groups/_groups.html.slim
@@ -17,7 +17,7 @@ h2.text-xl.font-bold.bg-base-yellow-50.border-l-8.border-main-orange-400.pl-3.py
             = link_to("https://github.com/#{group.owner.name}", target: '_blank', rel: 'noopener') do
               = image_tag(group.owner.image_url, class: 'min-w-10 h-10 rounded-full hover:opacity-50 mr-2', alt: '主催者のアイコン画像')
             div
-              = link_to group.details, group_path(group), class: 'font-bold nijikai-link-primary'
+              = link_to safe_join(group.details.split("\n"), tag.br), group_path(group), class: 'font-bold nijikai-link-primary'
               .flex.text-sm.pt-1
                 .flex.items-center.mr-4
                   i.fa-solid.fa-location-dot.mr-1

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -6,7 +6,7 @@
           = image_tag(post.user.image_url, class: 'w-6 h-6 rounded-full hover:opacity-50 mr-2', alt: '投稿者のアイコン画像')
         = link_to post.user.name, "https://github.com/#{post.user.name}", target: '_blank', rel: 'noopener', class: 'nijikai-link-primary'
       time.text-sm = l post.created_at, format: :short
-    p.px-2.pb-2 = post.content
+    p.px-2.pb-2 = safe_join(post.content.split("\n"), tag.br)
     = turbo_frame_tag "delete_button_#{post.id}" do
       - if post.created_by?(current_user)
         = render partial: 'posts/delete_button', locals: { group:, post: }


### PR DESCRIPTION
## Issue
- #166 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [ ] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- `group.details`の改行を表示反映した
  - `/groups`と`/groups/{ID}`
- `post.content`の改行を表示反映した
  - `/groups/{ID}`

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [【Rails】タグのエスケープ & 連続した改行の反映 - あまブログ](https://ama-tech.hatenablog.com/reflecting-tag-escaping-and-consecutive-line-breaks-in-rails)