### PR TITLE
コメント作成フォームの入力内容が空の場合は「コメントする」ボタンをdisabledにした

### DIFF
--- a/app/javascript/controllers/post_form_controller.js
+++ b/app/javascript/controllers/post_form_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="post-form"
+export default class extends Controller {
+  static targets = ["content", "submit"];
+
+  connect() {
+    this.toggleSubmitButton();
+  }
+
+  toggleSubmitButton() {
+    const isEmpty = this.contentTarget.value.trim() === "";
+    this.submitTarget.disabled = isEmpty;
+  }
+
+  onInput() {
+    this.toggleSubmitButton();
+  }
+}

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,6 +1,6 @@
 = turbo_frame_tag 'new_post' do
-  = form_with(model: [group, post], class: 'flex flex-col') do |form|
+  = form_with(model: [group, post], class: 'flex flex-col', data: { controller: 'post-form' }) do |form|
     = render 'application/errors', object: post
-    = form.text_area :content, placeholder: 'コメントを入力', class: 'rounded-md p-2 mb-2'
+    = form.text_area :content, placeholder: 'コメントを入力', class: 'rounded-md p-2 mb-2', data: { action: 'input->post-form#onInput', post_form_target: 'content' }
     .text-center
-      = form.submit 'コメントする', class: 'btn nijikai-btn-primary w-full max-w-64 sm:max-w-80'
+      = form.submit 'コメントする', class: 'btn nijikai-btn-primary w-full max-w-64 sm:max-w-80 disabled:bg-main-orange-400 disabled:text-white/60', data: { post_form_target: 'submit' }

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Posts', type: :system do
       it 'displays the post form' do
         visit group_path(group)
         expect(page).to have_field 'post_content'
-        expect(page).to have_button 'コメントする'
+        expect(page).to have_button 'コメントする', disabled: true
       end
     end
 
@@ -106,23 +106,6 @@ RSpec.describe 'Posts', type: :system do
       end
     end
 
-    context 'with empty input' do
-      before do
-        login_as(user)
-      end
-
-      it 'does not create the post and displays an error message' do
-        visit group_path(group)
-
-        expect do
-          click_button 'コメントする'
-          expect(page).to have_content 'コメントを入力してください'
-        end.not_to change(Post, :count)
-
-        expect(page).to have_current_path(group_path(group))
-      end
-    end
-
     context 'with more than 1000 characters' do
       before do
         login_as(user)
@@ -132,7 +115,7 @@ RSpec.describe 'Posts', type: :system do
         visit group_path(group)
 
         expect do
-          fill_in 'post_content', with: 'a' * 2001
+          fill_in 'post_content', with: 'a' * 1001
           click_button 'コメントする'
           expect(page).to have_content 'コメントは1000文字以内で入力してください'
         end.not_to change(Post, :count)


### PR DESCRIPTION
## Issue
- #168 

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- コメント作成フォームの入力内容が空の場合は「コメントする」ボタンをdisabledにした
- disabled時のデザインを修正した

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [Stimulus Handbook - 2: Hello, Stimulus](https://stimulus.hotwired.dev/handbook/hello-stimulus)
- [チュートリアル3 Stimulusで管理画面をもっとSPA風にする](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-3)
- [Hover, focus, and other states - Core concepts - Tailwind CSS](https://tailwindcss.com/docs/hover-focus-and-other-states#required-and-disabled)
